### PR TITLE
[FEAT] feat: 타임 캡슐 보관함 페이지 API 연결

### DIFF
--- a/src/api/directoryLetter.ts
+++ b/src/api/directoryLetter.ts
@@ -1,0 +1,48 @@
+import axios from 'axios';
+
+interface ILetterData {
+  id: number;
+  content: string;
+  createdAt: { seconds: number };
+}
+
+export const fetchLetterData = async (pageType: string) => {
+  try {
+    const apiUrl =
+      pageType === '일일회고'
+        ? 'http://localhost:4000/api/timecapsule/reflect'
+        : 'http://localhost:4000/api/timecapsule/letter';
+
+    const response = await axios.get(apiUrl, {
+      withCredentials: true,
+    });
+
+    const formattedData = response.data.map((item: ILetterData) => {
+      const date = new Date(item.createdAt.seconds * 1000);
+      let formattedDate: string = '';
+
+      if (pageType === '타임캡슐') {
+        const options: Intl.DateTimeFormatOptions = { month: 'long' };
+        formattedDate = new Intl.DateTimeFormat('ko-KR', options).format(date);
+      } else if (pageType === '일일회고') {
+        const options: Intl.DateTimeFormatOptions = {
+          month: 'long',
+          day: 'numeric',
+        };
+
+        formattedDate = new Intl.DateTimeFormat('ko-KR', options).format(date);
+      }
+
+      return {
+        id: item.id,
+        content: item.content,
+        createdAt: formattedDate,
+      };
+    });
+
+    return formattedData;
+  } catch (error) {
+    console.error('데이터를 가져오는 데 오류가 발생했습니다:', error);
+    return [];
+  }
+};

--- a/src/components/timecapsule/directory/Capsules.tsx
+++ b/src/components/timecapsule/directory/Capsules.tsx
@@ -1,0 +1,32 @@
+import * as S from '../../../styles/timecapsule/directory/Directory.style';
+import { CAPSULE_IMAGE } from '../../../mock/capsule';
+
+interface ICapsuleContainer {
+  letterData: { id: number; createdAt: string }[];
+  pageType: string;
+}
+
+const CapsuleContainer = ({ letterData, pageType }: ICapsuleContainer) => {
+  return (
+    <S.CapsuleContainer>
+      {letterData.map((data, index) => (
+        <S.CapsuleBox key={data.id}>
+          <S.CapsuleLabelBox>
+            <S.CapsuleLabel>{data.createdAt}</S.CapsuleLabel>
+          </S.CapsuleLabelBox>
+          <a
+            href={
+              pageType === '타임캡슐'
+                ? `/detail/letter/${data.id}`
+                : `/detail/reflect/${data.id}`
+            }
+          >
+            <S.CapsuleImg src={CAPSULE_IMAGE[index % CAPSULE_IMAGE.length]} />
+          </a>
+        </S.CapsuleBox>
+      ))}
+    </S.CapsuleContainer>
+  );
+};
+
+export default CapsuleContainer;

--- a/src/pages/timecapsule/directory/Directory.tsx
+++ b/src/pages/timecapsule/directory/Directory.tsx
@@ -1,100 +1,77 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-
 import MainLayout from '../../../layout/MainLayout';
 import Menu from '../../../components/common/Menu';
 import * as S from '../../../styles/timecapsule/directory/Directory.style';
-import { CAPSULE, CAPSULE_MAIN, CAPSULE_IMAGE } from '../../../mock/capsule';
+import CapsuleContainer from '../../../components/timecapsule/directory/Capsules';
+import { useUserStore } from '../../../store/userStore';
+import { fetchLetterData } from '../../../api/directoryLetter';
+import { handleButtonClick } from './directoryButtonUtil';
 
 function Directory() {
-	const navigate = useNavigate();
-	const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const navigate = useNavigate();
+  const nickname = useUserStore((state) => state.nickname);
 
-	const currentPath = window.location.pathname;
-	const isTimeCapsule = currentPath.includes('/directory/time');
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [letterData, setLetterData] = useState([]);
+  const [directoryState, setDirectoryState] = useState({
+    pageType: '타임캡슐',
+    buttonLabel: '일일회고 보러가기',
+  });
 
-	const [capsuleData, setCapsuleData] = useState(
-		isTimeCapsule ? CAPSULE_MAIN : CAPSULE,
-	);
-	const [directoryType, setDirectoryType] = useState(
-		isTimeCapsule ? '타임캡슐' : '일일회고',
-	);
-	const [directoryButton, setDirectoryButton] = useState(
-		isTimeCapsule ? '일일회고 보러가기' : '타임캡슐 보러가기',
-	);
-
-	const handleDirectoryButton = () => {
-		if (directoryButton === '타임캡슐 보러가기') {
-			setDirectoryButton('일일회고 보러가기');
-			setDirectoryType('타임캡슐');
-			setCapsuleData(CAPSULE_MAIN);
-			navigate(`/directory/time`);
-		}
-
-		if (directoryButton === '일일회고 보러가기') {
-			setDirectoryButton('타임캡슐 보러가기');
-			setDirectoryType('일일회고');
-			setCapsuleData(CAPSULE);
-			navigate(`/directory/diary`);
-		}
-	};
-
-	const toggleMenu = () => {
-		setIsMenuOpen((prev) => !prev);
-	};
+  const toggleMenu = () => {
+    setIsMenuOpen((prev) => !prev);
+  };
 
   const closeMenu = () => {
-		setIsMenuOpen(false);
-	};
+    setIsMenuOpen(false);
+  };
 
-	return (
-		<MainLayout>
-			<S.Header>
-				<S.LeftBox>
-					<S.LogoText href={`/main`}>Time Capsule</S.LogoText>
-					<S.TitleText>익명 님의 {directoryType} 보관함</S.TitleText>
-					<S.ChangeButton onClick={handleDirectoryButton}>
-						{directoryButton}
-					</S.ChangeButton>
-				</S.LeftBox>
-				<S.RightBox>
-					<S.MenuImg
-						src="/header/menu.svg"
-						width={35}
-						height={35}
-						onClick={toggleMenu}
-					/>
-					{isMenuOpen && (
-						<>
-							<S.Overlay onClick={closeMenu} />
-							<Menu />
-						</>
-					)}
-				</S.RightBox>
-			</S.Header>
-			<S.CapsuleContainer>
-				{capsuleData.map((data, index) => (
-					<S.CapsuleBox key={index}>
-						<S.CapsuleLabelBox>
-							<S.CapsuleLabel>{data.day}</S.CapsuleLabel>
-						</S.CapsuleLabelBox>
-						<a
-							href={
-								directoryType === '타임캡슐'
-									? '/detail/letter/1'
-									: '/detail/reflect/1'
-							}
-						>
-							<S.CapsuleImg
-								src={CAPSULE_IMAGE[index % CAPSULE_IMAGE.length]}
-								alt={data.day}
-							/>
-						</a>
-					</S.CapsuleBox>
-				))}
-			</S.CapsuleContainer>
-		</MainLayout>
-	);
+  useEffect(() => {
+    const loadData = async () => {
+      const data = await fetchLetterData(directoryState.pageType);
+      setLetterData(data);
+    };
+    loadData();
+  }, [directoryState.pageType]);
+
+  return (
+    <MainLayout>
+      <S.Header>
+        <S.LeftBox>
+          <S.LogoText href="/main">Time Capsule</S.LogoText>
+          <S.TitleText>
+            {nickname} 님의 {directoryState.pageType} 보관함
+          </S.TitleText>
+          <S.ChangeButton
+            onClick={() =>
+              handleButtonClick(directoryState, setDirectoryState, navigate)
+            }
+          >
+            {directoryState.buttonLabel}
+          </S.ChangeButton>
+        </S.LeftBox>
+        <S.RightBox>
+          <S.MenuImg
+            src="/header/menu.svg"
+            width={35}
+            height={35}
+            onClick={toggleMenu}
+          />
+          {isMenuOpen && (
+            <>
+              <S.Overlay onClick={closeMenu} />
+              <Menu />
+            </>
+          )}
+        </S.RightBox>
+      </S.Header>
+      <CapsuleContainer
+        letterData={letterData}
+        pageType={directoryState.pageType}
+      />
+    </MainLayout>
+  );
 }
 
 export default Directory;

--- a/src/pages/timecapsule/directory/directoryButtonUtil.ts
+++ b/src/pages/timecapsule/directory/directoryButtonUtil.ts
@@ -1,0 +1,39 @@
+import { useNavigate } from 'react-router-dom';
+
+interface IDirectoryButton {
+  directoryState: { pageType: string; buttonLabel: string };
+  navigate: ReturnType<typeof useNavigate>;
+  setDirectoryState: React.Dispatch<
+    React.SetStateAction<{ pageType: string; buttonLabel: string }>
+  >;
+}
+
+export const handleDirectoryButton = (
+  directoryState: IDirectoryButton['directoryState'],
+  setDirectoryState: IDirectoryButton['setDirectoryState'],
+) => {
+  const newPageType =
+    directoryState.pageType === '타임캡슐' ? '일일회고' : '타임캡슐';
+
+  const newButtonLabel =
+    directoryState.pageType === '타임캡슐'
+      ? '타임캡슐 보러가기'
+      : '일일회고 보러가기';
+
+  setDirectoryState((prev) => ({
+    ...prev,
+    pageType: newPageType,
+    buttonLabel: newButtonLabel,
+  }));
+
+  return newPageType;
+};
+
+export const handleButtonClick = (
+  directoryState: IDirectoryButton['directoryState'],
+  setDirectoryState: IDirectoryButton['setDirectoryState'],
+  navigate: IDirectoryButton['navigate'],
+) => {
+  const newPageType = handleDirectoryButton(directoryState, setDirectoryState);
+  navigate(`/directory/${newPageType === '타임캡슐' ? 'letter' : 'reflect'}`);
+};


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 타임 캡슐 보관함 페이지 API 연결

## 📝 작업 상세 내용

> 타임 캡슐 보관함 api 연결이 모두 완료되었습니다.

![time capsule](https://github.com/user-attachments/assets/fc6325a6-4c47-4693-ba38-f165f6478d3f)

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

> `zustand`로 상태 관리를 하고 있지 않고, `tanstack query`를 사용하지 않아 추후 리팩토링 시에 API 로직을 많이 손봐야 할 것 같습니다!
> 해당 페이지에서 사용하고 있는 API URI 요청 로직이 중복되는 것으로 보이는데, 페이지에 따라 다르게 호출되도록 구현한 거라 어떤 식으로 리팩토링하면 좋을지 고민 중입니다. 🤔 

> 또한 API를 사용하며 알게 되었는데 현재는 작성 시 날짜 제한이 없습니다! 하루에 여러 개의 편지를 작성 가능하고, 타임 캡슐의 경우 한 달에 한 번만 작성 가능한데 해당 예외 처리가 안 되어 있어 추가가 필요합니다. 

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

## 📸 스크린샷 (선택 사항)

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #37 
