### PR TITLE
[FEAT] feat: 편지 작성 제한 기능 추가

### DIFF
--- a/src/api/letter.ts
+++ b/src/api/letter.ts
@@ -1,5 +1,9 @@
 import axios from 'axios';
 
+interface ILetter {
+  createdAt: { seconds: number };
+}
+
 export const fetchLetterCount = async () => {
   try {
     const response = await axios.get(
@@ -19,13 +23,49 @@ export const fetchLetterCount = async () => {
 export const submitLetter = async (letter: string) => {
   try {
     const response = await axios.post(
-      'http://localhost:4000/api/timecapsule/letter', 
-      { content: letter },  
-      { withCredentials: true }
+      'http://localhost:4000/api/timecapsule/letter',
+      { content: letter },
+      { withCredentials: true },
     );
     console.log(response.data);
   } catch (error) {
     console.error('Error submitting letter:', error);
     throw error;
+  }
+};
+
+export const canWriteLetter = async () => {
+  try {
+    const response = await axios.get(
+      'http://localhost:4000/api/timecapsule/letter',
+      {
+        withCredentials: true,
+      },
+    );
+
+    if (response.data.length === 0) {
+      return true;
+    }
+
+    const sortedLetters = response.data
+      .sort(
+        (
+          a: { createdAt: { seconds: number } },
+          b: { createdAt: { seconds: number } },
+        ) => b.createdAt.seconds - a.createdAt.seconds,
+      )
+      .map((item: ILetter) => new Date(item.createdAt.seconds * 1000));
+
+    const latestLetterDate = sortedLetters[0];
+    const latestLetterMonth = latestLetterDate.getMonth();
+    const currentMonth = new Date().getMonth();
+
+    if (latestLetterMonth === currentMonth) {
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error('편지 작성 제한 체크 중 오류가 발생했습니다:', error);
+    return false;
   }
 };

--- a/src/components/timecapsule/main/LetterMenuOverlay.tsx
+++ b/src/components/timecapsule/main/LetterMenuOverlay.tsx
@@ -1,20 +1,28 @@
+import { canWriteLetter } from '../../../api/letter';
 import * as S from '../../../styles/timecapsule/main/LetterMenuOverlay.style';
 
 const LetterMenuOverlay = () => {
-	const handleNavigation = (path: string) => {
-		window.location.href = path;
-	};
+  const handleNavigation = async (path: string) => {
+    if (path === '/write/letter') {
+      const canWrite = await canWriteLetter();
+      if (!canWrite) {
+        alert('이번 달 편지를 작성하셨네요. 다음 달에 작성해주세요!');
+        return;
+      }
+    }
+    window.location.href = path;
+  };
 
-	return (
-		<S.OverlayContainer>
-			<S.OverlayContent onClick={() => handleNavigation('/write/letter')}>
-				2026년의 나에게 편지 작성하기
-			</S.OverlayContent>
-			<S.OverlayContent onClick={() => handleNavigation('/write/reflect')}>
-				오늘의 일기 작성하기
-			</S.OverlayContent>
-		</S.OverlayContainer>
-	);
+  return (
+    <S.OverlayContainer>
+      <S.OverlayContent onClick={() => handleNavigation('/write/letter')}>
+        2026년의 나에게 편지 작성하기
+      </S.OverlayContent>
+      <S.OverlayContent onClick={() => handleNavigation('/write/reflect')}>
+        오늘의 일기 작성하기
+      </S.OverlayContent>
+    </S.OverlayContainer>
+  );
 };
 
 export default LetterMenuOverlay;


### PR DESCRIPTION
## ✅ 체크리스트

- [x]  편지 작성 월별 제한 기능 구현

## 📝 작업 상세 내용

- 편지 작성 기능에 월별 제한을 추가
   - `canWriteLetter` 함수를 통해 현재 작성된 편지를 조회하고 최신 편지의 작성 월을 확인하여 제한을 적용 
   - 예를 들어, 이번 달에 이미 편지가 작성된 경우에 사용자는 더 이상 편지를 작성할 수 없도록 기능을 구현

- 편지 작성을 한 번도 하지 않았는데 작성 페이지로 넘어가지지 않는 문제
   - 빈 배열을 반환할 때도 편지를 작성할 수 없다고 인식되는 문제를 해결하기 위해 `response.data.length === 0`일 때는 작성할 수 있도록 처리

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/bbe7613f-e788-48c5-a224-30ca9238ccc7)

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reviewers, assignees, Lables 등록 확인하기

**이슈 번호**: #73 
