### PR TITLE
[BUG] fix: 회고 작성 후 보관함 페이지에서 타임 캡슐이 보이는 버그 수정

### DIFF
--- a/src/pages/timecapsule/directory/Directory.tsx
+++ b/src/pages/timecapsule/directory/Directory.tsx
@@ -8,15 +8,20 @@ import { useUserStore } from '../../../store/userStore';
 import { fetchLetterData } from '../../../api/directoryLetter';
 import { handleButtonClick } from './directoryButtonUtil';
 
-function Directory() {
+interface IDirectory {
+  pageType: string;
+}
+
+const Directory = ({ pageType }: IDirectory) => {
   const navigate = useNavigate();
   const nickname = useUserStore((state) => state.nickname);
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [letterData, setLetterData] = useState([]);
   const [directoryState, setDirectoryState] = useState({
-    pageType: '타임캡슐',
-    buttonLabel: '일일회고 보러가기',
+    pageType,
+    buttonLabel:
+      pageType === '일일회고' ? '타임캡슐 보러가기' : '일일회고 보러가기',
   });
 
   const toggleMenu = () => {
@@ -72,6 +77,6 @@ function Directory() {
       />
     </MainLayout>
   );
-}
+};
 
 export default Directory;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -14,7 +14,8 @@ import CategoryPage from './pages/todo/category/CategoryPage';
 const router = createBrowserRouter([
   { path: '/', element: <Login /> },
   { path: '/main', element: <MainPage /> },
-  { path: '/directory/:type', element: <Directory /> },
+  { path: '/directory/letter', element: <Directory pageType="타임캡슐" /> },
+  { path: '/directory/reflect', element: <Directory pageType="일일회고" /> },
   { path: '/write/letter', element: <LetterWritePage /> },
   { path: '/write/reflect', element: <ReflectWritePage /> },
   { path: '/detail/letter/:letterId', element: <LetterDetail /> },


### PR DESCRIPTION
## ✅ 체크리스트

- [x]  회고 작성 후 보관함 페이지에서 타임 캡슐이 보이는 버그 수정

## 📝 작업 상세 내용

> 하나의 라우터에서 `:type`으로만 두 보관함을 같이 관리하고 있다 보니 생긴 문제로 판단되어 라우터를 분리해 주었습니다. 

```
  { path: '/directory/letter', element: <Directory pageType="타임캡슐" /> },
  { path: '/directory/reflect', element: <Directory pageType="일일회고" /> },
```

> 이제 Directory component의 props로 pageType을 받게 됩니다.

```tsx
interface IDirectory {
  pageType: string;
}

const Directory = ({ pageType }: IDirectory) => {
  ...
}
```

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #77 
