### PR TITLE
[FEAT] feat: 유저 회원 탈퇴 기능 구현

### DIFF
--- a/src/components/common/Menu.tsx
+++ b/src/components/common/Menu.tsx
@@ -40,6 +40,25 @@ const Menu = () => {
     }
   };
 
+  const handleWithdraw = async () => {
+    try {
+      const response = await axios.delete(
+        'http://localhost:4000/api/withdraw',
+        {
+          withCredentials: true,
+        },
+      );
+
+      if (response.status === 200) {
+        alert(response.data.message);
+        navigate('/');
+      }
+    } catch (error) {
+      console.error('회원 탈퇴 실패:', error);
+      alert('회원 탈퇴에 실패했습니다.');
+    }
+  };
+
   return (
     <S.MenuContainer>
       {menuItems.map((item) => (
@@ -48,6 +67,7 @@ const Menu = () => {
         </S.MenuItem>
       ))}
       <S.MenuItem onClick={handleLogout}>로그아웃</S.MenuItem>
+      <S.MenuItem onClick={handleWithdraw}>회원 탈퇴</S.MenuItem>
     </S.MenuContainer>
   );
 };


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 유저 회원 탈퇴 기능 구현

## 📝 작업 상세 내용

> 회원 탈퇴 기능 구현이 완료되었습니다. 다만, 현재는 재가입이 가능하며 사용자의 카카오 정보는 회원 탈퇴 시 삭제되지만 **사용자가 서비스를 이용한 내역**은 삭제되지 않습니다. 때문에 재가입 시 이용 내역이 그대로 남아 있는 상태입니다. 

![withdraw](https://github.com/user-attachments/assets/640ce9e8-3877-43a3-a7b2-9964db38d31a)

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

> 서버 API 수정이 필요합니다. 또한, 회원 탈퇴 시 주의 사항을 표시해 주는 dialog가 필요합니다. 
> 고도화 기간에 수정할 예정이며 약관에 관련된 내용은 팀원들끼리 같이 논의해 보면 좋을 듯합니다!

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

## 📸 스크린샷 (선택 사항)

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #82 
