### PR TITLE
[FEAT] feat: 타임캡슐 상세 페이지 API 연결

### DIFF
--- a/src/pages/timecapsule/detail/LetterDetail.jsx
+++ b/src/pages/timecapsule/detail/LetterDetail.jsx
@@ -1,43 +1,52 @@
-import React from 'react';
-import { useLocation } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
 import html2canvas from 'html2canvas';
 import jsPDF from 'jspdf';
 import * as S from '../../../styles/timecapsule/detail/LetterDetail.style';
+import { fetchLetterData } from '../../../api/directoryLetter';
 
 const LetterDetail = () => {
-	const location = useLocation();
-	const { letterContent } = location.state || {
-		letterContent: {
-			to: '2026년의 나에게 보내는 편지',
-			body: '미래의 나에게 보내는 메시지를 여기에 작성했습니다. 1년 동안 많은 일들이 있었겠지요?',
-			from: '2025년의 내가 보내는 편지',
-		},
-	};
+  const { letterId } = useParams();
+  const location = useLocation();
+  const [letterData, setLetterData] = useState([]);
 
-	const handleDownload = () => {
-		const input = document.getElementById('letter');
-		html2canvas(input).then((canvas) => {
-			const imgData = canvas.toDataURL('image/png');
-			const pdf = new jsPDF();
-			pdf.addImage(imgData, 'PNG', 10, 10, 190, 0);
-			pdf.save('letter-detail.pdf');
-		});
-	};
+  useEffect(() => {
+    const loadData = async () => {
+      const data = await fetchLetterData('타임캡슐');
 
-	return (
-		<S.LetterDetailContainer>
-			<S.BackButton onClick={() => window.history.back()}>&larr;</S.BackButton>
-			<S.Title>💌작년 1월의 내가 미래의 나에게 보내온 편지💌</S.Title>
-			<S.LetterContent id="letter">
-				<S.ToText>To. {letterContent.to}</S.ToText>
-				<S.BodyText>{letterContent.body}</S.BodyText>
-				<S.FromText>from. {letterContent.from}</S.FromText>
-			</S.LetterContent>
-			<S.DownloadButton onClick={handleDownload}>
-				📥 PDF로 다운로드
-			</S.DownloadButton>
-		</S.LetterDetailContainer>
-	);
+      const selectedLetter = data.find((letter) => letter.id === letterId);
+      setLetterData(selectedLetter || null);
+    };
+
+    loadData();
+  }, [letterId]);
+
+  console.log(letterData);
+
+  const handleDownload = () => {
+    const input = document.getElementById('letter');
+    html2canvas(input).then((canvas) => {
+      const imgData = canvas.toDataURL('image/png');
+      const pdf = new jsPDF();
+      pdf.addImage(imgData, 'PNG', 10, 10, 190, 0);
+      pdf.save('letter-detail.pdf');
+    });
+  };
+
+  return (
+    <S.LetterDetailContainer>
+      <S.BackButton onClick={() => window.history.back()}>&larr;</S.BackButton>
+      <S.Title>
+        💌 2025년 {letterData.createdAt}의 내가 미래의 나에게 보낸 편지 💌
+      </S.Title>
+      <S.LetterContent id="letter">
+        <S.BodyText>{letterData.content}</S.BodyText>
+      </S.LetterContent>
+      <S.DownloadButton onClick={handleDownload}>
+        📥 PDF로 다운로드
+      </S.DownloadButton>
+    </S.LetterDetailContainer>
+  );
 };
 
 export default LetterDetail;

--- a/src/pages/timecapsule/detail/ReflectDetail.jsx
+++ b/src/pages/timecapsule/detail/ReflectDetail.jsx
@@ -1,44 +1,49 @@
-import React from 'react';
-import { useLocation } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import html2canvas from 'html2canvas';
 import jsPDF from 'jspdf';
 import * as S from '../../../styles/timecapsule/detail/ReflectDetail.style';
+import { fetchLetterData } from '../../../api/directoryLetter';
 
 const ReflectDetail = () => {
-	const location = useLocation();
-	const { letterContent } = location.state || {
-		letterContent: {
-			to: '나에게',
-			body: '오늘의 나에게 보내는 메시지를 여기에 작성했습니다.',
-			from: '오늘의 내가',
-		},
-	};
+  const location = useLocation();
+  const { letterId } = useParams();
+  const [letterData, setLetterData] = useState([]);
 
-	const handleDownload = () => {
-		const input = document.getElementById('letter');
-		html2canvas(input).then((canvas) => {
-			const imgData = canvas.toDataURL('image/png');
-			const pdf = new jsPDF();
-			pdf.addImage(imgData, 'PNG', 10, 10, 190, 0);
-			pdf.save('letter-detail.pdf');
-		});
-	};
+  useEffect(() => {
+    const loadData = async () => {
+      const data = await fetchLetterData('일일회고');
 
-	return (
-		<S.ReflectDetailContainer>
-			<S.BackButton onClick={() => window.history.back()}>&larr;</S.BackButton>
-			<S.Title>💌2026년 1월 1일 나에게 작성한 편지💌</S.Title>
-			<S.ReflectContent id="letter">
-				<S.ToText>To. {letterContent.to}</S.ToText>
-				<S.BodyText>{letterContent.body}</S.BodyText>
-				<S.FromText>from. {letterContent.from}</S.FromText>
-			</S.ReflectContent>
-			<S.DownloadButton onClick={handleDownload}>
-				📥 PDF로 다운로드
-			</S.DownloadButton>
-		</S.ReflectDetailContainer>
-	);
+      const selectedLetter = data.find((letter) => letter.id === letterId);
+      setLetterData(selectedLetter || null);
+    };
+
+    loadData();
+  }, []);
+
+  const handleDownload = () => {
+    const input = document.getElementById('letter');
+    html2canvas(input).then((canvas) => {
+      const imgData = canvas.toDataURL('image/png');
+      const pdf = new jsPDF();
+      pdf.addImage(imgData, 'PNG', 10, 10, 190, 0);
+      pdf.save('letter-detail.pdf');
+    });
+  };
+
+  return (
+    <S.ReflectDetailContainer>
+      <S.BackButton onClick={() => window.history.back()}>&larr;</S.BackButton>
+      <S.Title>🍀 2026년 {letterData.createdAt} 일일 회고 🍀</S.Title>
+      <S.ReflectContent id="letter">
+        <S.BodyText>{letterData.content}</S.BodyText>
+      </S.ReflectContent>
+      <S.DownloadButton onClick={handleDownload}>
+        📥 PDF로 다운로드
+      </S.DownloadButton>
+    </S.ReflectDetailContainer>
+  );
 };
 
 export default ReflectDetail;


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 타임 캡슐 상세 페이지 API 연결 `/api/timecapsule/letter`
- [x] 일일 회고 상세 페이지 API 연결 `/api/timecapsule/reflect`

## 📝 작업 상세 내용

> 편지 구성 내용 일부가 수정되었습니다. 스스로에게 보내는 편지이기 때문에 사용자 이름이 표시되지 않아도 된다고 판단하여 내용만 나타나도록 수정해 주었습니다. 단, UI가 밋밋해 보여서 편지 작성 페이지와 통일이 필요해 보입니다. 🥺

<img width="1468" alt="스크린샷 2025-01-12 오후 10 28 35" src="https://github.com/user-attachments/assets/064a4f9e-1192-4c2c-bbca-50198cd732d0" />

> 타임 캡슐도 동일하게 수정되었습니다. 만일 타임 캡슐 페이지의 편지 내용을 확인하고 싶으시다면 `/api/letter.ts`의 `canReadLetter()` 내부 `now` 값을 아래와 같이 변경해 주세요. 

```ts
// const now = new Date().getTime(); 현재 코드
const now = new Date('2026-01-01').getTime();
```

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

- 상세 페이지 UI 통일 필요
- 편지 내용 및 디자인 논의 필요 

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

## 📸 스크린샷 (선택 사항)

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #84 
