### PR TITLE
[REFACTOR] refactor: API URL .env 파일로 이동

### DIFF
--- a/src/api/category.ts
+++ b/src/api/category.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import API from '.';
 
 type CategoryData = {
   categoryName: string;
@@ -14,16 +14,12 @@ type Category = {
 
 export const registerCategory = async (categoryData: CategoryData) => {
   try {
-    const response = await axios.post(
-      `http://localhost:4000/api/todo/category`,
-      categoryData,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        withCredentials: true,
+    const response = await API.post(`/todo/category`, categoryData, {
+      headers: {
+        'Content-Type': 'application/json',
       },
-    );
+      withCredentials: true,
+    });
     console.log(response.data);
   } catch (error) {
     console.error('Error registering category:', error);
@@ -32,12 +28,9 @@ export const registerCategory = async (categoryData: CategoryData) => {
 
 export const fetchCategories = async () => {
   try {
-    const response = await axios.get(
-      `http://localhost:4000/api/todo/category`,
-      {
-        withCredentials: true,
-      },
-    );
+    const response = await API.get(`/todo/category`, {
+      withCredentials: true,
+    });
 
     const categories = response.data.map((item: Category) => {
       const date = new Date(item.createdAt.seconds * 1000);
@@ -64,12 +57,9 @@ export const fetchCategories = async () => {
 
 export const deleteCategory = async (categoryId: string) => {
   try {
-    const response = await axios.delete(
-      `http://localhost:4000/api/todo/category/${categoryId}`,
-      {
-        withCredentials: true,
-      },
-    );
+    const response = await API.delete(`/todo/category/${categoryId}`, {
+      withCredentials: true,
+    });
     return response.data;
   } catch (error) {
     console.error('Error deleting category:', error);

--- a/src/api/directoryLetter.ts
+++ b/src/api/directoryLetter.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import API from '.';
 
 interface ILetterData {
   id: number;
@@ -9,11 +9,9 @@ interface ILetterData {
 export const fetchLetterData = async (pageType: string) => {
   try {
     const apiUrl =
-      pageType === '일일회고'
-        ? 'http://localhost:4000/api/timecapsule/reflect'
-        : 'http://localhost:4000/api/timecapsule/letter';
+      pageType === '일일회고' ? '/timecapsule/reflect' : '/timecapsule/letter';
 
-    const response = await axios.get(apiUrl, {
+    const response = await API.get(apiUrl, {
       withCredentials: true,
     });
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+export const API_URI = import.meta.env.VITE_API_URI;
+
+const API = axios.create({
+  baseURL: `${API_URI}/api`,
+});
+
+export default API;

--- a/src/api/letter.ts
+++ b/src/api/letter.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import API from '.';
 
 interface ILetter {
   createdAt: { seconds: number };
@@ -7,12 +7,9 @@ interface ILetter {
 
 export const fetchLetterCount = async () => {
   try {
-    const response = await axios.get(
-      'http://localhost:4000/api/timecapsule/letter',
-      {
-        withCredentials: true,
-      },
-    );
+    const response = await API.get('/timecapsule/letter', {
+      withCredentials: true,
+    });
 
     return response.data.length;
   } catch (error) {
@@ -23,8 +20,8 @@ export const fetchLetterCount = async () => {
 
 export const submitLetter = async (letter: string) => {
   try {
-    const response = await axios.post(
-      'http://localhost:4000/api/timecapsule/letter',
+    const response = await API.post(
+      '/timecapsule/letter',
       { content: letter },
       { withCredentials: true },
     );
@@ -37,12 +34,9 @@ export const submitLetter = async (letter: string) => {
 
 export const canWriteLetter = async () => {
   try {
-    const response = await axios.get(
-      'http://localhost:4000/api/timecapsule/letter',
-      {
-        withCredentials: true,
-      },
-    );
+    const response = await API.get('/timecapsule/letter', {
+      withCredentials: true,
+    });
 
     if (response.data.length === 0) {
       return true;
@@ -73,12 +67,9 @@ export const canWriteLetter = async () => {
 
 export const canReadLetter = async () => {
   try {
-    const response = await axios.get(
-      'http://localhost:4000/api/timecapsule/letter',
-      {
-        withCredentials: true,
-      },
-    );
+    const response = await API.get('/timecapsule/letter', {
+      withCredentials: true,
+    });
 
     const letterData = response.data.map((item: ILetter) => ({
       canReadDate: new Date(item.canReadDate.seconds * 1000),

--- a/src/api/reflect.ts
+++ b/src/api/reflect.ts
@@ -1,9 +1,9 @@
-import axios from 'axios';
+import API from '.';
 
 export const submitReflect = async (reflect: string, emoji: string) => {
   try {
-    const response = await axios.post(
-      'http://localhost:4000/api/timecapsule/reflect',
+    const response = await API.post(
+      '/timecapsule/reflect',
       { content: reflect, emoji },
       { withCredentials: true },
     );

--- a/src/api/todo.ts
+++ b/src/api/todo.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import API from '.';
 
 interface ITodo {
   id: number;
@@ -10,8 +10,8 @@ interface ITodo {
 
 export const addTodo = async (task: string, categoryId: string) => {
   try {
-    const response = await axios.post(
-      `http://localhost:4000/api/todo/task`,
+    const response = await API.post(
+      `/todo/task`,
       {
         task,
         categoryId,
@@ -28,7 +28,7 @@ export const addTodo = async (task: string, categoryId: string) => {
 
 export const fetchTodoData = async () => {
   try {
-    const response = await axios.get(`http://localhost:4000/api/todo/task`, {
+    const response = await API.get(`/todo/task`, {
       withCredentials: true,
     });
 
@@ -57,8 +57,8 @@ export const fetchTodoData = async () => {
 
 export const updateTodo = async (todoId: string, isCompleted: boolean) => {
   try {
-    const response = await axios.patch(
-      `http://localhost:4000/api/todo/task/${todoId}`,
+    const response = await API.patch(
+      `/todo/task/${todoId}`,
       {
         isCompleted,
       },
@@ -74,12 +74,9 @@ export const updateTodo = async (todoId: string, isCompleted: boolean) => {
 
 export const deleteTodo = async (todoId: string) => {
   try {
-    const response = await axios.delete(
-      `http://localhost:4000/api/todo/task/${todoId}`,
-      {
-        withCredentials: true,
-      },
-    );
+    const response = await API.delete(`/todo/task/${todoId}`, {
+      withCredentials: true,
+    });
     console.log(response.data);
     return response.data;
   } catch (error) {

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,8 +1,8 @@
-import axios from "axios";
+import API from '.';
 
 export const fetchUserData = async () => {
   try {
-    const response = await axios.get(`http://localhost:4000/api/user`, {
+    const response = await API.get(`/user`, {
       withCredentials: true,
     });
 

--- a/src/components/common/Menu.tsx
+++ b/src/components/common/Menu.tsx
@@ -1,6 +1,6 @@
 import * as S from '../../styles/common/Menu.style';
 import { useLocation, useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import API from '../../api';
 
 const Menu = () => {
   const location = useLocation();
@@ -27,8 +27,8 @@ const Menu = () => {
 
   const handleLogout = async () => {
     try {
-      const response = await axios.post(
-        'http://localhost:4000/api/logout',
+      const response = await API.post(
+        '/logout',
         {},
         {
           withCredentials: true,
@@ -42,12 +42,9 @@ const Menu = () => {
 
   const handleWithdraw = async () => {
     try {
-      const response = await axios.delete(
-        'http://localhost:4000/api/withdraw',
-        {
-          withCredentials: true,
-        },
-      );
+      const response = await API.delete('/withdraw', {
+        withCredentials: true,
+      });
 
       if (response.status === 200) {
         alert(response.data.message);


### PR DESCRIPTION
## ✅ 체크리스트

- [x] API URL .env 파일로 이동

## 📝 작업 상세 내용

> 서버 도메인 노출 위험을 줄이기 위해 API URL을 .env 파일에 작성해 주었습니다. 또한, API 기초 설정을 해 두었으니 앞으로는 `/timecapsule/letter`와 같이 URI만 입력하시고 요청해 주시면 됩니다!

## 🚨 버그 발생 이유 (선택 사항)

> 현재 401 에러가 발생 중입니다. 도메인이 달라 웹 사이트 측에서 쿠키 전송을 막고 있어서로 추정됩니다. 😭 프론트 배포 후 테스트가 필요해 보입니다!

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

## 📸 스크린샷 (선택 사항)

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #86 
