### PR TITLE
[BUG] fix: 달력에 할 일 개수 실시간 반영되지 않는 오류 및 달력 기능/UI 수정

### DIFF
--- a/src/api/letter.ts
+++ b/src/api/letter.ts
@@ -94,9 +94,8 @@ export const canReadLetter = async () => {
       canReadDate: new Date(item.canReadDate.seconds * 1000),
     }));
 
-    // const now = new Date().getTime();
-    // const now = new Date('2026-01-01').getTime();
-    const now = new Date('2026-02-01').getTime();
+    const now = new Date().getTime();
+    // const now = new Date('2026-02-01').getTime();
 
     for (const item of letterData) {
       if (now >= item.canReadDate.getTime()) {

--- a/src/components/todo/main/Calendar.jsx
+++ b/src/components/todo/main/Calendar.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import * as S from '../../../styles/todo/main/Calendar.style';
 import { useUserStore } from '../../../store/userStore';
 import dayjs from 'dayjs';

--- a/src/components/todo/main/Calendar.jsx
+++ b/src/components/todo/main/Calendar.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import * as S from '../../../styles/todo/main/Calendar.style';
 import { useUserStore } from '../../../store/userStore';
 import dayjs from 'dayjs';
@@ -97,8 +97,13 @@ const CustomCalendar = ({ onDateChange }) => {
 
   const handleDateChange = (date) => {
     setCurrentDate(date);
-    onDateChange(date);
   };
+
+  useEffect(() => {
+    if (currentDate) {
+      onDateChange(currentDate);
+    }
+  }, [currentDate]);
 
   return (
     <S.CalendarContainer>

--- a/src/components/todo/main/Calendar.jsx
+++ b/src/components/todo/main/Calendar.jsx
@@ -11,6 +11,7 @@ const CustomCalendar = ({ onDateChange }) => {
   const nickname = useUserStore((state) => state.nickname);
   const profileImage = useUserStore((state) => state.profileImage);
   const [completedCount, setCompletedCount] = useState(0);
+  const today = new Date();
 
   const { todoQuery } = useTodo();
   const todos = todoQuery.data?.todos ?? [];
@@ -81,6 +82,11 @@ const CustomCalendar = ({ onDateChange }) => {
   const tileClassName = ({ date, view }) => {
     if (view === 'month') {
       const day = date.getDay();
+      const isToday = date.toDateString() === today.toDateString();
+      const isSelected = date.toDateString() === currentDate.toDateString();
+
+      if (isSelected) return '';
+      if (isToday) return 'today';
 
       if (day === 0) return 'sunday';
       if (day === 6) return 'saturday';

--- a/src/components/todo/main/Calendar.jsx
+++ b/src/components/todo/main/Calendar.jsx
@@ -85,11 +85,10 @@ const CustomCalendar = ({ onDateChange }) => {
       const isToday = date.toDateString() === today.toDateString();
       const isSelected = date.toDateString() === currentDate.toDateString();
 
-      if (isSelected) return '';
-      if (isToday) return 'today';
-
       if (day === 0) return 'sunday';
       if (day === 6) return 'saturday';
+      if (isSelected) return '';
+      if (isToday) return 'today';
     }
     return '';
   };

--- a/src/components/todo/main/Calendar.jsx
+++ b/src/components/todo/main/Calendar.jsx
@@ -3,6 +3,7 @@ import * as S from '../../../styles/todo/main/Calendar.style';
 import { useUserStore } from '../../../store/userStore';
 import dayjs from 'dayjs';
 import { fetchTodoData } from '../../../api/todo';
+import useTodo from '../../../hooks/useTodo';
 
 const CustomCalendar = ({ onDateChange }) => {
   const [currentDate, setCurrentDate] = useState(new Date());
@@ -10,27 +11,32 @@ const CustomCalendar = ({ onDateChange }) => {
   const nickname = useUserStore((state) => state.nickname);
   const profileImage = useUserStore((state) => state.profileImage);
   const [completedCount, setCompletedCount] = useState(0);
-  const [todos, setTodos] = useState([]);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      const { todos, completedCount } = await fetchTodoData();
-      setCompletedCount(completedCount);
-      setTodos(todos);
-    };
+  const { todoQuery } = useTodo();
+  const todos = todoQuery.data?.todos ?? [];
 
-    fetchData();
+  const completedTodosForMonth = (month) => {
+    return todos.filter((todo) => {
+      const todoDate = new Date(todo.createdAt);
+      return todoDate.getMonth() === month && todo.isCompleted;
+    }).length;
+  };
 
-    const handleTodoUpdated = (event) => {
-      fetchData();
-    };
+  const todosCountForDate = (date) => {
+    return todos.filter(
+      (todo) =>
+        new Date(todo.createdAt).toDateString() ===
+        new Date(date).toDateString(),
+    ).length;
+  };
 
-    window.addEventListener('todoUpdated', handleTodoUpdated);
-
-    return () => {
-      window.removeEventListener('todoUpdated', handleTodoUpdated);
-    };
-  }, []);
+  const todosCompletedCountForDate = (date) => {
+    return todos.filter(
+      (todo) =>
+        new Date(todo.createdAt).toDateString() ===
+          new Date(date).toDateString() && todo.isCompleted,
+    ).length;
+  };
 
   const tileDisabled = ({ date, view }) => {
     if (view === 'month') {
@@ -43,11 +49,8 @@ const CustomCalendar = ({ onDateChange }) => {
 
   const tileContent = ({ date, view }) => {
     if (view === 'month') {
-      const todosForDate = todos.filter(
-        (todo) =>
-          dayjs(todo.createdAt).format('YYYY-MM-DD') ===
-          dayjs(date).format('YYYY-MM-DD'),
-      ).length;
+      const todosForDate = todosCountForDate(date);
+      const completedTodosForDate = todosCompletedCountForDate(date);
 
       if (todosForDate > 0) {
         return (
@@ -65,7 +68,9 @@ const CustomCalendar = ({ onDateChange }) => {
               color: 'black',
             }}
           >
-            {todosForDate}
+            {todosForDate - completedTodosForDate === 0
+              ? '✔️'
+              : todosForDate - completedTodosForDate}
           </div>
         );
       }
@@ -73,16 +78,27 @@ const CustomCalendar = ({ onDateChange }) => {
     return null;
   };
 
+  const tileClassName = ({ date, view }) => {
+    if (view === 'month') {
+      const day = date.getDay();
+
+      if (day === 0) return 'sunday';
+      if (day === 6) return 'saturday';
+    }
+    return '';
+  };
+
   const handleActiveStartDateChange = ({ activeStartDate }) => {
     setActiveStartDate(activeStartDate);
+    setCurrentDate(
+      new Date(activeStartDate.getFullYear(), activeStartDate.getMonth(), 1),
+    );
   };
 
   const handleDateChange = (date) => {
     setCurrentDate(date);
     onDateChange(date);
   };
-
-  console.log(completedCount);
 
   return (
     <S.CalendarContainer>
@@ -110,11 +126,15 @@ const CustomCalendar = ({ onDateChange }) => {
         nextLabel=">"
         tileDisabled={tileDisabled}
         tileContent={tileContent}
+        tileClassName={tileClassName}
         onActiveStartDateChange={handleActiveStartDateChange}
+        showNeighboringMonth={false}
         navigationLabel={() => (
           <S.TodoStatusBar>
             {dayjs(activeStartDate).format('YYYY년 M월')}
-            <span>☑️ {completedCount}</span>
+            <span>
+              ☑️ {completedTodosForMonth(dayjs(activeStartDate).month())}
+            </span>
           </S.TodoStatusBar>
         )}
       />

--- a/src/styles/todo/main/Calendar.style.ts
+++ b/src/styles/todo/main/Calendar.style.ts
@@ -9,13 +9,13 @@ export const CalendarContainer = styled.div`
 `;
 
 export const TileContent = styled.div`
-  position: "absolute";
-  top: "9px";
-  left: "50%";
-  transform: "translateX(-50%)";
-  fontSize: "12px";
-  fontWeight: "bold";
-  color: "black;
+  position: 'absolute';
+  top: '9px';
+  left: '50%';
+  transform: 'translateX(-50%)';
+  font-size: '12px';
+  font-weight: 'bold';
+  color: 'black';
 `;
 
 export const ProfileHeader = styled.div`
@@ -53,6 +53,7 @@ export const StyledCalendar = styled(Calendar)`
   max-width: 660px;
   border: none;
   font-size: 15px;
+  font-weight: bold;
 
   .react-calendar__month-view__weekdays {
     display: grid;
@@ -79,10 +80,11 @@ export const StyledCalendar = styled(Calendar)`
     display: grid;
     grid-template-columns: repeat(7, 1fr);
     grid-template-rows: repeat(6, 1fr);
-	  width: 600px; height: 340px;
+    width: 600px;
+    height: 340px;
   }
 
-  .react-calendar__month-view__days :disabled{
+  .react-calendar__month-view__days :disabled {
     color: transparent;
     background: none !important;
     pointer-events: none;
@@ -92,6 +94,14 @@ export const StyledCalendar = styled(Calendar)`
     &::before {
       display: none;
     }
+  }
+
+  .saturday {
+    color: #6fa8ff !important;
+  }
+
+  .sunday {
+    color: #ff6f6f !important;
   }
 
   .calendar-tile::before {
@@ -121,11 +131,7 @@ export const StyledCalendar = styled(Calendar)`
     cursor: pointer;
     transition: all 0.3s ease;
     position: relative;
-
-    &:hover {
-      background-color: rgba(0, 0, 0, 0.1);
-      border-radius: 5px;
-    }
+    /* height: 55px; */
 
     &::before {
       content: '';
@@ -135,7 +141,7 @@ export const StyledCalendar = styled(Calendar)`
       transform: translateX(-50%);
       width: 22px;
       height: 22px;
-      background-color: lightgray;
+      background-color: #d3d8db;
       border-radius: 5px;
     }
 
@@ -151,6 +157,13 @@ export const StyledCalendar = styled(Calendar)`
       border: none;
       margin: auto;
       pointer-events: none;
+    }
+    &.react-calendar__tile--active.saturday abbr {
+      color: #6fa8ff;
+    }
+
+    &.react-calendar__tile--active.sunday abbr {
+      color: #ff6f6f;
     }
   }
 

--- a/src/styles/todo/main/Calendar.style.ts
+++ b/src/styles/todo/main/Calendar.style.ts
@@ -131,6 +131,7 @@ export const StyledCalendar = styled(Calendar)`
     cursor: pointer;
     transition: all 0.3s ease;
     position: relative;
+    height: 68px;
 
     &::before {
       content: '';

--- a/src/styles/todo/main/Calendar.style.ts
+++ b/src/styles/todo/main/Calendar.style.ts
@@ -157,6 +157,21 @@ export const StyledCalendar = styled(Calendar)`
       margin: auto;
       pointer-events: none;
     }
+
+    &.react-calendar__tile.today abbr {
+      background-color: #dadde2;
+      color: black;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border: none;
+      margin: auto;
+      pointer-events: none;
+    }
+
     &.react-calendar__tile--active.saturday abbr {
       color: #6fa8ff;
     }

--- a/src/styles/todo/main/Calendar.style.ts
+++ b/src/styles/todo/main/Calendar.style.ts
@@ -131,7 +131,6 @@ export const StyledCalendar = styled(Calendar)`
     cursor: pointer;
     transition: all 0.3s ease;
     position: relative;
-    /* height: 55px; */
 
     &::before {
       content: '';


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 달력 할 일 개수 실시간 반영 오류 수정
- [x] 달력 토요일 일요일 색깔 지정
- [x] 해당 날짜에 할 일을 다 완료했으면 체크 표시로 이모지 바꿔 줌
- [x] 달력 이동 시 해당 월의 첫 번째 날짜 자동 선택 및 투두 리스트 업데이트
- [x] 달력 높이를 고정하여 월별 크기 변동 문제 해결
- [x] 선택한 날짜와 현재 날짜 구분을 위한 스타일 개선

## 📝 작업 상세 내용

- 달력 할 일 개수 실시간 반영 오류 수정
  - 할 일 개수 업데이트가 제대로 반영되지 않던 문제를 수정
  - 데이터 변경 시 달력이 실시간으로 업데이트 되도록 개선

- 달력 토요일 일요일 색깔 지정
  - 주말(토요일, 일요일)에 다른 색상을 지정하여 구분을 명확하게 개선

- 해당 날짜에 할 일을 다 완료했으면 체크 표시로 이모지 바꿔 줌

- 달력 이동 시 해당 월의 첫 번째 날짜 자동 선택 및 투두 리스트 업데이트

- 선택한 날짜와 현재 날짜 구분을 위한 스타일 개선
  - 기존에는 선택된 날짜만 강조되었는데 현재 날짜에 회색 배경을 추가하여 다른 날짜를 클릭해도 오늘 날짜를 쉽게 구분할 수 있도록 개선

- 달력 높이를 고정하여 월별 크기 변동 문제 해결
  - 달력의 각 날짜 높이를 고정하여 월별 크기가 달라지지 않도록 설정

## 🚨 버그 발생 이유 (선택 사항)
- 할 일 개수 실시간 반영 오류는 데이터를 비동기적으로 처리하면서 달력 UI에 실시간으로 바로 반영되지 않는 문제
  - TanStack Query를 사용해 데이터를 가져오고 업데이트하도록 변경하여 문제를 해결

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #111 
