### PR TITLE
[BUG] fix: 달력에서 월 단위 이상의 선택을 제한하도록 수정

### DIFF
--- a/src/api/letter.ts
+++ b/src/api/letter.ts
@@ -1,27 +1,9 @@
-import axios from 'axios';
 import API from '.';
 
 interface ILetter {
   createdAt: { seconds: number };
   canReadDate: { seconds: number };
 }
-
-// Reflect 데이터 받아오기
-export const fetchReflectData = async () => {
-  try {
-    const response = await axios.get(
-      'http://localhost:4000/api/timecapsule/reflect',
-      {
-        withCredentials: true, // 쿠키와 세션을 함께 보냄
-      },
-    );
-    console.log('Reflect Data:', response.data); // 데이터 확인용
-    return response.data;
-  } catch (error) {
-    console.error('Error fetching reflect data:', error);
-    throw error;
-  }
-};
 
 export const fetchLetterCount = async () => {
   try {

--- a/src/api/reflect.ts
+++ b/src/api/reflect.ts
@@ -13,3 +13,17 @@ export const submitReflect = async (reflect: string, emoji: string) => {
     throw error;
   }
 };
+
+// Reflect 데이터 받아오기
+export const fetchReflectData = async () => {
+  try {
+    const response = await API.get('/timecapsule/reflect', {
+      withCredentials: true, // 쿠키와 세션을 함께 보냄
+    });
+    console.log('Reflect Data:', response.data); // 데이터 확인용
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching reflect data:', error);
+    throw error;
+  }
+};

--- a/src/components/todo/main/Calendar.jsx
+++ b/src/components/todo/main/Calendar.jsx
@@ -139,13 +139,9 @@ const CustomCalendar = ({ onDateChange }) => {
         tileClassName={tileClassName}
         onActiveStartDateChange={handleActiveStartDateChange}
         showNeighboringMonth={false}
+        minDetail="month"
         navigationLabel={() => (
-          <S.TodoStatusBar
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-          >
+          <S.TodoStatusBar>
             {dayjs(activeStartDate).format('YYYY년 M월')}
             <span>
               ☑️ {completedTodosForMonth(dayjs(activeStartDate).month())}

--- a/src/styles/todo/main/Calendar.style.ts
+++ b/src/styles/todo/main/Calendar.style.ts
@@ -131,7 +131,7 @@ export const StyledCalendar = styled(Calendar)`
     cursor: pointer;
     transition: all 0.3s ease;
     position: relative;
-    height: 68px;
+    height: 4.25rem;
 
     &::before {
       content: '';
@@ -225,6 +225,7 @@ export const TodoStatusBar = styled.div`
   justify-content: space-between;
   width: 100%;
   max-width: 600px;
+  color: black;
 
   span {
     margin-left: 15px;


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 월/년/십년/세기별 선택되지 않도록 수정

## 📝 작업 상세 내용
<img src='https://github.com/user-attachments/assets/39814610-b956-441e-b5e4-81ad62f509ac' width=400 />

지현님께서 같은 오류를 수정하셨는데(PR #120) 위 사진에서 노란색으로 표시한 부분을 클릭하면 여전히 동일한 문제가 발생하였습니다.
React Calendar의 `minDetail='month'`를 사용하여 달력을 월 단위로만 표시하도록 설정했습니다.  

추가로 `fetchReflectData`가 `letter.ts` 파일에 있어서 `reflect.ts` 파일로 이동하였습니다.
현재 사용하고 있는 api는 아니지만 추후 상세 페이지에서 사용할 세부 정보를 가져오는 api로 수정해야할 것 같습니다.

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reviewers, assignees, Lables 등록 확인하기

**이슈 번호**: #122 
