### PR TITLE
[BUG] fix: 할 일 작성 중 카테고리를 변경하면 내용이 유지되는 문제 수정

### DIFF
--- a/src/components/todo/main/AddTodo.tsx
+++ b/src/components/todo/main/AddTodo.tsx
@@ -50,8 +50,8 @@ export default function AddTodo({ selectedDate }: AddTodoProps) {
   }, []);
 
   const handleCategoryClick = (id: string) => {
-    console.log(id);
     setActiveCategory((prev) => (prev === id ? null : id));
+    setTask('');
   };
 
   const handleWriteTodo = (e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## ✅ 체크리스트

- [x]  카테고리를 변경할 때 입력 중이던 할 일 초기화

## 📝 작업 상세 내용

할 일 입력 도중 카테고리를 변경하면 기존 입력 값이 유지되는 문제가 발생하여 이를 수정하였습니다.

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reviewers, assignees, Lables 등록 확인하기

**이슈 번호**: #124 
