### PR TITLE
[FEAT] feat & design Letter/Reflect Detail 페이지 PDF 다운로드 내용

### DIFF
--- a/src/pages/timecapsule/detail/LetterDetail.jsx
+++ b/src/pages/timecapsule/detail/LetterDetail.jsx
@@ -39,32 +39,33 @@ const LetterDetail = () => {
 	}, [letterId]); // letterId가 변경될 때마다 실행
 
 	const handleDownload = () => {
-		// const input = document.getElementById('letter');
-		const input = inputRef.current;
-
-		html2canvas(input).then((canvas) => {
+		const textContainer = inputRef.current.querySelector('.text-container');
+		
+		html2canvas(textContainer).then((canvas) => {
 			const imgData = canvas.toDataURL('image/png');
 			const pdf = new jsPDF();
 			pdf.addImage(imgData, 'PNG', 10, 10, 190, 0);
 			pdf.save('letter-detail.pdf');
 		});
-	};
+	};	
 
 	return (
-		<S.LetterDetailContainer>
+		<S.LetterDetailContainer ref={inputRef}>
 			<StarsBackground />
 
 			<S.BackButton onClick={() => window.history.back()}>
 				&larr;
 			</S.BackButton>
 
-			<S.Title>
-				💌 {letterContent ? new Date(letterContent.createdAt.seconds * 1000).toISOString().split("T")[0] : "로딩 중..."}의 내가 미래의 나에게 보내온 편지 💌
-			</S.Title>
+			<div className="text-container">
+				<S.Title>
+					💌 {letterContent ? new Date(letterContent.createdAt.seconds * 1000).toISOString().split("T")[0] : "로딩 중..."}의 내가 미래의 나에게 보내온 편지 💌
+				</S.Title>
 
-			<S.LetterContent ref={inputRef} id="letter">
-				<S.BodyText>{letterContent?.content || "로딩 중..."}</S.BodyText>
-			</S.LetterContent>
+				<S.LetterContent ref={inputRef} id="letter">
+					<S.BodyText>{letterContent?.content || "로딩 중..."}</S.BodyText>
+				</S.LetterContent>
+			</div>
 
 			<S.DownloadButton onClick={handleDownload}>
 				📥 PDF로 다운로드

--- a/src/pages/timecapsule/detail/ReflectDetail.jsx
+++ b/src/pages/timecapsule/detail/ReflectDetail.jsx
@@ -52,7 +52,6 @@ const ReflectDetail = () => {
 
   const handleDownload = () => {
     const textContainer = inputRef.current.querySelector('.text-container');
-    console.log(textContainer);
   
     html2canvas(textContainer).then((canvas) => {
       const imgData = canvas.toDataURL('image/png');

--- a/src/pages/timecapsule/detail/ReflectDetail.jsx
+++ b/src/pages/timecapsule/detail/ReflectDetail.jsx
@@ -51,9 +51,10 @@ const ReflectDetail = () => {
   }, [letterId]); 
 
   const handleDownload = () => {
-    const input = inputRef.current;
-    console.log(input);
-    html2canvas(input).then((canvas) => {
+    const textContainer = inputRef.current.querySelector('.text-container');
+    console.log(textContainer);
+  
+    html2canvas(textContainer).then((canvas) => {
       const imgData = canvas.toDataURL('image/png');
       const pdf = new jsPDF();
       pdf.addImage(imgData, 'PNG', 10, 10, 190, 0);
@@ -62,26 +63,28 @@ const ReflectDetail = () => {
   };
 
   return (
-    <S.ReflectDetailContainer>
+    <S.ReflectDetailContainer ref={inputRef}>
       <StarsBackground />
 
       <S.BackButton onClick={() => window.history.back()}>
         &larr;
       </S.BackButton>
 
-      <S.Title>
-        🍀 {currentYear}년 {reflectData?.createdAt || "날짜 없음"} 일일 회고 🍀
-      </S.Title>
+      <div className="text-container">
+        <S.Title>
+          🍀 {currentYear}년 {reflectData?.createdAt || "날짜 없음"} 일일 회고 🍀
+        </S.Title>
 
-      <S.ReflectContent ref={inputRef} id="letter">
-        <S.BodyText>
-          {selectedEmotion ? `오늘의 감정 : ${selectedEmotion}` : ''}
-        </S.BodyText>
+        <S.ReflectContent id="letter">
+          <S.BodyText>
+            {selectedEmotion ? `오늘의 감정 : ${selectedEmotion}` : ''}
+          </S.BodyText>
 
-        <S.BodyText>
-          {reflectData?.content || '회고 내용이 없습니다.'}
-        </S.BodyText>
-      </S.ReflectContent>
+          <S.BodyText>
+            {reflectData?.content || '회고 내용이 없습니다.'}
+          </S.BodyText>
+        </S.ReflectContent>
+      </div>
 
       <S.DownloadButton onClick={handleDownload}>
         📥 PDF로 다운로드

--- a/src/styles/timecapsule/detail/LetterDetail.style.ts
+++ b/src/styles/timecapsule/detail/LetterDetail.style.ts
@@ -44,7 +44,8 @@ export const Title = styled.h1`
 
 export const LetterContent = styled.div`
 	background-color: white;
-	width: 1300px; height: 540px;
+	width: 1100px; height: 540px;
+	padding-top: 10px;
 	border-radius: 20px;
 `;
 

--- a/src/styles/timecapsule/detail/ReflectDetail.style.ts
+++ b/src/styles/timecapsule/detail/ReflectDetail.style.ts
@@ -5,7 +5,6 @@ export const ReflectDetailContainer = styled.div`
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	overflow: hidden;
 `;
 
 export const BackButton = styled.button`
@@ -30,7 +29,7 @@ export const BackButton = styled.button`
 export const Title = styled.h1`
 	font-size: 26px;
 	font-weight: bold;
-	text-align: left;
+	text-align: center;
 	margin-bottom: 50px;
 	margin-top: 20px;
 
@@ -43,29 +42,12 @@ export const Title = styled.h1`
 
 export const ReflectContent = styled.div`
 	background-color: white;
-	width: 60%; height: 60vh;
+	width: 1000px; height: 60vh;
 	border-radius: 20px;
 `;
 
-export const ToText = styled.p`
-	font-weight: bold;
-	margin-bottom: 10px;
-	position: absolute;
-	top: 180px;
-	left: 130px;
-`;
-
 export const BodyText = styled.p`
-	margin: 30px 20px;
-	line-height: 1.0;
-`;
-
-export const FromText = styled.p`
-	margin-top: 20px;
-	margin-right: -50px;
-	font-weight: bold;
-	text-align: right;
-	font-style: italic;
+	padding-top: 30px; padding-left: 30px;
 `;
 
 export const DownloadButton = styled.button`


### PR DESCRIPTION
## ✅ 체크리스트

- [X]  LetterDetail PDF 다운로드 시 title까지 다운로드 되게 하기
- [X]  div 때문에 크기가 달라져서 LetterDetail.style.ts 파일 수정
- [X] ReflectDetail PDF 다운로드 시 title까지 다운로드 되게 하기
- [X] div 때문에 크기가 달라져서 ReflectDetail.style.ts 파일 수정

## 📝 작업 상세 내용

LetterDetail 페이지는 PDF 다운로드 시 content 내용만 다운로드 됐었는데 이젠 title까지 다운로드 되게 변경했습니다.
style 수정한 건 div를 추가했더니 흰색 박스 부분이 크기가 이상해져서 변경했습니다.

ReflectDetail 페이지도 마찬가지로 title까지 포함돼서 PDF로 다운로드 되게 변경했습니다.
위와 같이 style 같은 이유로 수정했습니다.

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/a06f5276-784f-4984-ad11-cc3206353195)
![image](https://github.com/user-attachments/assets/da6661c5-cc91-40cb-88f5-9b42dec50d75)

![image](https://github.com/user-attachments/assets/4a55c2f6-37c7-467b-83f4-113ec18a0bdb)
![image](https://github.com/user-attachments/assets/31de28bc-53e2-454a-a007-ec7efafbf4f6)

## ✅ 셀프 체크리스트

- [X]  브랜치 확인하기
- [X]  불필요한 코드가 들어가지 않았는지 재확인하기
- [X]  issue 닫기
- [X]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #126 
