### PR TITLE
[FEAT] feat: beforeunload 이벤트 리스너 추가하여 새로고침 및 페이지 이탈 방지

### DIFF
--- a/src/pages/timecapsule/write/LetterWritePage.tsx
+++ b/src/pages/timecapsule/write/LetterWritePage.tsx
@@ -1,8 +1,22 @@
 import * as S from '../../../styles/timecapsule/write/WritePage.style';
 import WriteForm from '../../../components/timecapsule/write/WriteForm';
 import { StarsBackground } from '../../../components/timecapsule/write/StarsBackground';
+import { useEffect } from 'react';
 
 export default function LetterWritePage() {
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
   return (
     <S.WriteContainer>
       <StarsBackground />

--- a/src/pages/timecapsule/write/ReflectWritePage.tsx
+++ b/src/pages/timecapsule/write/ReflectWritePage.tsx
@@ -1,10 +1,9 @@
 import * as S from '../../../styles/timecapsule/write/WritePage.style';
 import WriteForm from '../../../components/timecapsule/write/WriteForm';
 import { StarsBackground } from '../../../components/timecapsule/write/StarsBackground';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function ReflectWritePage() {
-
   const emotions = [
     { id: 'angry', emoji: '😠' },
     { id: 'sad', emoji: '😢' },
@@ -13,17 +12,32 @@ export default function ReflectWritePage() {
     { id: 'excited', emoji: '😆' },
   ];
 
-  const [selectedEmotion, setSelectedEmotion] = useState<string | undefined>(undefined);
+  const [selectedEmotion, setSelectedEmotion] = useState<string | undefined>(
+    undefined,
+  );
 
   const handleEmotionChange = (emotion: string) => {
     setSelectedEmotion((prev) => (prev === emotion ? undefined : emotion));
   };
-  
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
   return (
     <S.WriteContainer>
       <StarsBackground />
       <S.TitleContainer>
-        <S.Title>오늘의 회고</S.Title>
+        <S.Title>오늘의 일기</S.Title>
         <S.SubTitle>오늘은 어떤 하루였나요?</S.SubTitle>
       </S.TitleContainer>
       <S.EmotionBox>


### PR DESCRIPTION
## ✅ 체크리스트

- [x]  편지, 회고(일기) 페이지에 beforeunload 이벤트를 활용하여 사용자가 페이지를 이탈하려 할 때 경고 메시지를 띄움
- [x] 사용자 입력이 감지된 경우에만 경고창이 나타나도록 구현

## 📝 작업 상세 내용

사용자가 입력한 데이터가 있는 상태에서 실수로 새로고침하거나 페이지를 벗어나는 것을 방지하기 위해 beforeunload 이벤트 리스너를 추가했습니다.

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #130 
