### PR TITLE
[REFACTOR] refactor: 카테고리 CRUD 기능을 Tanstack Query로 통합

### DIFF
--- a/src/components/todo/main/AddTodo.tsx
+++ b/src/components/todo/main/AddTodo.tsx
@@ -1,21 +1,14 @@
 import { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from 'react';
 import * as S from '../../../styles/todo/main/AddTodo.style';
-import { fetchCategories } from '../../../api/category';
 import dayjs from 'dayjs';
 import useTodo from '../../../hooks/useTodo';
-
-type category = {
-  id: string;
-  categoryName: string;
-  textColor: string;
-};
+import useCategory from '../../../hooks/useCategory';
 
 type AddTodoProps = {
   selectedDate: string;
 };
 
 export default function AddTodo({ selectedDate }: AddTodoProps) {
-  const [categories, setCategories] = useState<category[]>([]);
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [task, setTask] = useState<string>('');
   const [isMenuOpen, setIsMenuOpen] = useState<string | null>(null);
@@ -30,20 +23,11 @@ export default function AddTodo({ selectedDate }: AddTodoProps) {
   } = useTodo();
   const todos = todoQuery.data?.todos ?? [];
 
+  const { categoryQuery } = useCategory();
+  const categories = categoryQuery.data ?? [];
+
   useEffect(() => {
-    const getCategories = async () => {
-      try {
-        const data = await fetchCategories();
-        setCategories(data);
-      } catch (error) {
-        console.error('Error fetching categories:', error);
-      }
-    };
-
-    getCategories();
-
     document.addEventListener('mousedown', handleClickOutside);
-
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
@@ -118,83 +102,89 @@ export default function AddTodo({ selectedDate }: AddTodoProps) {
         </S.MsgContainer>
       ) : (
         <S.CategoryListContainer>
-          {categories.map((category) => (
-            <div>
-              <S.CategoryItem
-                key={category.id}
-                textColor={category.textColor}
-                onClick={() => handleCategoryClick(category.id)}
-              >
-                {category.categoryName}
-                <S.PlusButton>＋</S.PlusButton>
-              </S.CategoryItem>
+          {categories.map(
+            (category: {
+              id: string;
+              textColor: string;
+              categoryName: string;
+            }) => (
+              <div>
+                <S.CategoryItem
+                  key={category.id}
+                  textColor={category.textColor}
+                  onClick={() => handleCategoryClick(category.id)}
+                >
+                  {category.categoryName}
+                  <S.PlusButton>＋</S.PlusButton>
+                </S.CategoryItem>
 
-              {Array.isArray(todos) &&
-                todos.map((todo) => {
-                  if (
-                    selectedDate ===
-                      dayjs(todo.createdAt).format('YYYY-MM-DD') &&
-                    todo.categoryId === category.id
-                  ) {
-                    return (
-                      <S.TodoItem key={todo.id}>
-                        <S.CheckBox
-                          type="checkbox"
-                          textColor={category.textColor}
-                          checked={todo.isCompleted}
-                          onChange={() =>
-                            handleCheckBoxChange(todo.id, todo.isCompleted)
-                          }
-                        />
-                        <S.TodoText>{todo.task}</S.TodoText>
+                {Array.isArray(todos) &&
+                  todos.map((todo) => {
+                    if (
+                      selectedDate ===
+                        dayjs(todo.createdAt).format('YYYY-MM-DD') &&
+                      todo.categoryId === category.id
+                    ) {
+                      return (
+                        <S.TodoItem key={todo.id}>
+                          <S.CheckBox
+                            type="checkbox"
+                            textColor={category.textColor}
+                            checked={todo.isCompleted}
+                            onChange={() =>
+                              handleCheckBoxChange(todo.id, todo.isCompleted)
+                            }
+                          />
+                          <S.TodoText>{todo.task}</S.TodoText>
 
-                        <S.TodoMenu onClick={() => toggleDropdown(todo.id)}>
-                          •••
-                        </S.TodoMenu>
+                          <S.TodoMenu onClick={() => toggleDropdown(todo.id)}>
+                            •••
+                          </S.TodoMenu>
 
-                        {isMenuOpen === todo.id && (
-                          <S.DropdownMenu ref={menuRef}>
-                            <S.DropdownItem>수정</S.DropdownItem>
-                            <S.DropdownItem
-                              onClick={() => handleDeleteTodo(todo.id)}
-                            >
-                              삭제
-                            </S.DropdownItem>
-                          </S.DropdownMenu>
-                        )}
-                      </S.TodoItem>
-                    );
-                  }
-                  return null;
-                })}
+                          {isMenuOpen === todo.id && (
+                            <S.DropdownMenu ref={menuRef}>
+                              <S.DropdownItem>수정</S.DropdownItem>
+                              <S.DropdownItem
+                                onClick={() => handleDeleteTodo(todo.id)}
+                              >
+                                삭제
+                              </S.DropdownItem>
+                            </S.DropdownMenu>
+                          )}
+                        </S.TodoItem>
+                      );
+                    }
+                    return null;
+                  })}
 
-              {activeCategory === category.id && (
-                <S.InputGroup>
-                  <S.CheckBox
-                    type="checkbox"
-                    textColor={category.textColor}
-                    checked={false}
-                  />
-                  <S.TodoInput
-                    type="text"
-                    placeholder="할 일 입력"
-                    textColor={category.textColor}
-                    value={task}
-                    onChange={handleWriteTodo}
-                    onKeyDown={(e) => handleKeyDown(e, category.id)}
-                    ref={inputRef}
-                    autoFocus
-                  />
-                  <S.AddButton
-                    textColor={category.textColor}
-                    onClick={() => handleAddTodo(category.id)}
-                  >
-                    추가
-                  </S.AddButton>
-                </S.InputGroup>
-              )}
-            </div>
-          ))}
+                {activeCategory === category.id && (
+                  <S.InputGroup>
+                    <S.CheckBox
+                      type="checkbox"
+                      textColor={category.textColor}
+                      checked={false}
+                    />
+                    <S.TodoInput
+                      type="text"
+                      placeholder="할 일 입력"
+                      textColor={category.textColor}
+                      value={task}
+                      onChange={handleWriteTodo}
+                      onKeyDown={(e) => handleKeyDown(e, category.id)}
+                      ref={inputRef}
+                      autoFocus
+                    />
+                    <S.AddButton
+                      textColor={category.textColor}
+                      onClick={() => handleAddTodo(category.id)}
+                    >
+                      추가
+                    </S.AddButton>
+                  </S.InputGroup>
+                )}
+              </div>
+            ),
+          )}
         </S.CategoryListContainer>
       )}
     </S.TodoContainer>

--- a/src/hooks/useCategory.tsx
+++ b/src/hooks/useCategory.tsx
@@ -1,0 +1,52 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  deleteCategory,
+  fetchCategories,
+  modifiedCategory,
+  registerCategory,
+} from '../api/category';
+
+export default function useCategory() {
+  const queryClient = useQueryClient();
+
+  const categoryQuery = useQuery({
+    queryKey: ['categories'],
+    queryFn: fetchCategories,
+  });
+
+  const addCategoryMutation = useMutation({
+    mutationFn: (categoryData: { categoryName: string; textColor: string }) =>
+      registerCategory(categoryData),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+    },
+  });
+
+  const modifiedCategoryMutation = useMutation({
+    mutationFn: ({
+      categoryData,
+      categoryId,
+    }: {
+      categoryData: { categoryName: string; textColor: string };
+      categoryId: string;
+    }) => modifiedCategory(categoryData, categoryId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+    },
+  });
+
+  const deletedCategoryMutation = useMutation({
+    mutationFn: ({ categoryId }: { categoryId: string }) =>
+      deleteCategory(categoryId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+    },
+  });
+
+  return {
+    categoryQuery,
+    addCategoryMutation,
+    modifiedCategoryMutation,
+    deletedCategoryMutation,
+  };
+}

--- a/src/pages/todo/category/CategoryPage.tsx
+++ b/src/pages/todo/category/CategoryPage.tsx
@@ -1,29 +1,22 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import CategoryHeader from '../../../components/todo/category/CategoryHeader';
 import MainLayout from '../../../layout/MainLayout';
 import * as S from '../../../styles/todo/category/Category.style';
-import { deleteCategory, fetchCategories, modifiedCategory } from '../../../api/category';
 import CategoryModal from '../../../components/todo/category/CategoryModal';
+import useCategory from '../../../hooks/useCategory';
 
 const CategoryPage = () => {
-  const [categories, setCategories] = useState([]);
-  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null);
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
+    null,
+  );
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isEdit, setIsEdit] = useState(false);
   const [categoryName, setCategoryName] = useState('');
   const [textColor, setTextColor] = useState('');
+  const { categoryQuery, modifiedCategoryMutation, deletedCategoryMutation } =
+    useCategory();
 
-  useEffect(() => {
-    const loadCategories = async () => {
-        try {
-          const categoryData = await fetchCategories();
-          setCategories(categoryData);
-        } catch (error) {
-          console.error('Failed to load category data:', error);
-        }
-    };
-    loadCategories();
-  }, []);
+  const categories = categoryQuery.data ?? [];
 
   const handleModalClose = () => {
     setIsEdit(false);
@@ -40,7 +33,10 @@ const CategoryPage = () => {
     setTextColor(color);
   };
 
-  const handleCategoryChange = (field: 'categoryName' | 'textColor', value: string) => {
+  const handleCategoryChange = (
+    field: 'categoryName' | 'textColor',
+    value: string,
+  ) => {
     if (field === 'categoryName') {
       setCategoryName(value);
     } else if (field === 'textColor') {
@@ -52,29 +48,28 @@ const CategoryPage = () => {
     setIsEdit(true);
   };
 
-  const handleModifyComplete = async () => {
+  const handleModifyComplete = () => {
     try {
-      await modifiedCategory({ categoryName, textColor }, selectedCategoryId);
-      setCategories((prevCategories) =>
-        prevCategories.map((category) =>
-          category.id === selectedCategoryId ? { ...category, categoryName, textColor } : category
-        )
-      );
+      if (!selectedCategoryId) return;
+      modifiedCategoryMutation.mutate({
+        categoryData: { categoryName, textColor },
+        categoryId: selectedCategoryId,
+      });
     } catch (error) {
       console.error('수정 중 오류 발생:', error);
       alert('수정 중 문제가 발생했습니다.');
     } finally {
       handleModalClose();
     }
-  }
+  };
 
-  const handleConfirmDelete = async () => {
+  const handleConfirmDelete = () => {
     if (!selectedCategoryId) return;
     try {
-      await deleteCategory(selectedCategoryId);
-      setCategories((prevCategories) =>
-        prevCategories.filter((category) => category.id !== selectedCategoryId)
-      );
+      if (!selectedCategoryId) return;
+      deletedCategoryMutation.mutate({
+        categoryId: selectedCategoryId,
+      });
     } catch (error) {
       console.error('삭제 중 오류 발생:', error);
       alert('삭제 중 문제가 발생했습니다.');
@@ -89,27 +84,35 @@ const CategoryPage = () => {
       <S.CategoryList>
         {Array.isArray(categories) && categories.length > 0 ? (
           categories.map((category, index) => (
-            <S.CategoryItem key={index} textColor={category.textColor} onClick={() => handleEditClick(category.id, category.categoryName, category.textColor)}>
+            <S.CategoryItem
+              key={index}
+              textColor={category.textColor}
+              onClick={() =>
+                handleEditClick(
+                  category.id,
+                  category.categoryName,
+                  category.textColor,
+                )
+              }
+            >
               {category.categoryName}
             </S.CategoryItem>
           ))
         ) : (
           <S.EmptyMessage>
-            등록된 카테고리가 없습니다. <br />
-            새 카테고리를 추가해보세요!
+            등록된 카테고리가 없습니다. <br />새 카테고리를 추가해보세요!
           </S.EmptyMessage>
-        )
-      }
+        )}
       </S.CategoryList>
       {isModalOpen && (
         <CategoryModal
-        onClose={handleModalClose}
-        onModify={handleModifyOpen}
-        onModifyComplete={handleModifyComplete}
-        isEdit={isEdit}
-        onConfirm={handleConfirmDelete}
-        categoryName={categoryName}
-        onCategoryChange={handleCategoryChange}
+          onClose={handleModalClose}
+          onModify={handleModifyOpen}
+          onModifyComplete={handleModifyComplete}
+          isEdit={isEdit}
+          onConfirm={handleConfirmDelete}
+          categoryName={categoryName}
+          onCategoryChange={handleCategoryChange}
         />
       )}
     </MainLayout>


### PR DESCRIPTION
## ✅ 체크리스트

- [x]  카테고리 CRUD 기능을 Tanstack Query로 통합
- [x]  기존 useEffect에서의 데이터 가져오기 방식 제거

## 📝 작업 상세 내용

- 카테고리 관련 기능들을 Tanstack Query로 통합하여 API 요청을 처리하는 방식에서 useQuery와 useMutation을 활용하도록 변경
- 기존에 사용하던 `useEffect`와 수동 상태 업데이트 방식은 Tanstack Query로 대체하여 실시간 데이터 페칭, 캐싱, 동기화를 효율적으로 처리하도록 개선
  - Todo 기능에 이미 적용된 Tanstack Query 방식과 통일성 있게 적용하여 코드 일관성을 높임


## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reviewers, assignees, Lables 등록 확인하기

**이슈 번호**: #132 
