### PR TITLE
[UI] design: 메인, 달력, Todo, Header 페이지 레이아웃 및 스타일 전반 수정

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -4,45 +4,68 @@ import * as S from '../../styles/common/Header.style';
 import Menu from './Menu';
 import { useUserStore } from '../../store/userStore';
 
-const Header = () => {
-	const location = useLocation();
-	const nav = useNavigate();
-	const [isMenuOpen, setIsMenuOpen] = useState(false);
-	const nickname = useUserStore((state) => state.nickname);
-	const isTodo = location.pathname.startsWith('/todo');
+interface HeaderProps {
+  pageType?: string;
+}
 
-	const getTitle = () => {
-		if(location.pathname.startsWith('/main')) return `" ${nickname} "님의 타임캡슐`;
-		if(location.pathname.startsWith('/todo')) return `" ${nickname} "님의 할 일 목록`;
-	}
+const Header = ({ pageType }: HeaderProps) => {
+  const location = useLocation();
+  const nav = useNavigate();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const nickname = useUserStore((state) => state.nickname);
+  const isTodo = location.pathname.startsWith('/main');
 
-	const handleMainNav = () => {
-		nav('/main');
-	}
+  const getTitle = () => {
+    if (location.pathname.startsWith('/main'))
+      return `${nickname}님의 타임캡슐`;
+    if (location.pathname.startsWith('/todo'))
+      return `${nickname}님의 할 일 목록`;
+    if (location.pathname.startsWith('/directory'))
+      return `${nickname} 님의 ${pageType} 보관함`;
+  };
 
-	const toggleMenu = () => {
-		setIsMenuOpen((prev) => !prev);
-	}
+  const handleMainNav = () => {
+    nav('/main');
+  };
 
-	const closeMenu = () => {
-		setIsMenuOpen(false);
-	};
+  const toggleMenu = () => {
+    setIsMenuOpen((prev) => !prev);
+  };
 
-	return (
-		<S.HeaderContainer>
-			<S.LogoContainer isTodo={isTodo} onClick={handleMainNav}>Time Capsule</S.LogoContainer>
-			<S.HeaderTitle isTodo={isTodo}>{getTitle()}</S.HeaderTitle>
-			<S.MenuContainer onClick={toggleMenu} isTodo={isTodo}>
-				<img src="/main/Menu.svg" width={35} height={35} />
-			</S.MenuContainer>
-			{isMenuOpen && (
-				<>
-					<S.Overlay onClick={closeMenu} />
-					<Menu />
-				</>
-			)}
-		</S.HeaderContainer>
-	);
+  const closeMenu = () => {
+    setIsMenuOpen(false);
+  };
+
+  const handleButtonClick = () => {
+    if (pageType === '일일회고') {
+      nav('/directory/letter');
+    } else {
+      nav('/directory/reflect');
+    }
+  };
+
+  return (
+    <S.HeaderContainer>
+      <S.LogoContainer isTodo={isTodo} onClick={handleMainNav}>
+        Time Capsule
+      </S.LogoContainer>
+      <S.HeaderTitle isTodo={isTodo}>{getTitle()}</S.HeaderTitle>
+      {location.pathname.startsWith('/directory') && (
+        <S.ChangeButton onClick={handleButtonClick}>
+          {pageType === '일일회고' ? '타임캡슐 보러가기' : '일일회고 보러가기'}
+        </S.ChangeButton>
+      )}
+      <S.MenuContainer onClick={toggleMenu} isTodo={isTodo}>
+        <img src="/main/Menu.svg" width={35} height={35} />
+      </S.MenuContainer>
+      {isMenuOpen && (
+        <>
+          <S.Overlay onClick={closeMenu} />
+          <Menu />
+        </>
+      )}
+    </S.HeaderContainer>
+  );
 };
 
 export default Header;

--- a/src/components/common/Menu.tsx
+++ b/src/components/common/Menu.tsx
@@ -1,9 +1,8 @@
 import * as S from '../../styles/common/Menu.style';
-import * as Layout from '../../styles/layout/MainLayout.style';
 import { useLocation, useNavigate } from 'react-router-dom';
 import API from '../../api';
 
-const Menu: React.FC<{ type: string }> = ({ type }) => {
+const Menu = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -57,20 +56,8 @@ const Menu: React.FC<{ type: string }> = ({ type }) => {
     }
   };
 
-  return type !== 'directory' ? (
-    <Layout.MainLayoutContainer>
-      <S.MenuContainer type={type}>
-        {menuItems.map((item) => (
-          <S.MenuItem key={item.path} onClick={() => handleNavigate(item.path)}>
-            {item.label}
-          </S.MenuItem>
-        ))}
-        <S.MenuItem onClick={handleLogout}>로그아웃</S.MenuItem>
-        <S.MenuItem onClick={handleWithdraw}>회원 탈퇴</S.MenuItem>
-      </S.MenuContainer>
-    </Layout.MainLayoutContainer>
-  ) : (
-    <S.MenuContainer type={type}>
+  return (
+    <S.MenuContainer>
       {menuItems.map((item) => (
         <S.MenuItem key={item.path} onClick={() => handleNavigate(item.path)}>
           {item.label}

--- a/src/components/common/Menu.tsx
+++ b/src/components/common/Menu.tsx
@@ -17,6 +17,11 @@ const Menu = () => {
         { path: '/todo/category/new', label: '카테고리 등록' },
         { path: '/todo/category', label: '카테고리 관리' },
       ];
+    } else if (location.pathname.startsWith('/directory')) {
+      return [
+        { path: `/main`, label: '나의 타임캡슐' },
+        { path: `/todo`, label: '나의 Todo' },
+      ];
     } else {
       return [
         { path: `/todo`, label: '나의 Todo' },

--- a/src/components/timecapsule/main/CapsuleBox.tsx
+++ b/src/components/timecapsule/main/CapsuleBox.tsx
@@ -1,10 +1,10 @@
 import * as S from '../../../styles/timecapsule/main/CapsuleBox.style';
 
 const IMAGE_MAP = [
-	{ range: [1, 3], src: '/main/Box-2.png' },
-	{ range: [4, 8], src: '/main/Box-3.png' },
-	{ range: [9, 12], src: '/main/Box-4.png' },
-  ];
+  { range: [1, 3], src: '/main/Box-2.png' },
+  { range: [4, 8], src: '/main/Box-3.png' },
+  { range: [9, 12], src: '/main/Box-4.png' },
+];
 
 const CapsuleBox = ({ letterCount }) => {
   const handleCapsuleBox = () => {
@@ -13,7 +13,7 @@ const CapsuleBox = ({ letterCount }) => {
 
   const getImageSrc = () => {
     const found = IMAGE_MAP.find(
-      (item) => letterCount >= item.range[0] && letterCount <= item.range[1]
+      (item) => letterCount >= item.range[0] && letterCount <= item.range[1],
     );
     return found ? found.src : '/main/Box-1.png';
   };

--- a/src/components/todo/main/AddTodo.tsx
+++ b/src/components/todo/main/AddTodo.tsx
@@ -27,11 +27,12 @@ export default function AddTodo({ selectedDate }: AddTodoProps) {
   const categories = categoryQuery.data ?? [];
 
   useEffect(() => {
+    setActiveCategory(null);
     document.addEventListener('mousedown', handleClickOutside);
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, []);
+  }, [selectedDate]);
 
   const handleCategoryClick = (id: string) => {
     setActiveCategory((prev) => (prev === id ? null : id));

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,7 +1,7 @@
 import * as S from '../styles/layout/MainLayout.style';
 
 function MainLayout({ children }: { children: React.ReactNode }) {
-	return <S.MainLayoutContainer>{children}</S.MainLayoutContainer>;
+  return <S.MainLayoutContainer>{children}</S.MainLayoutContainer>;
 }
 
 export default MainLayout;

--- a/src/pages/timecapsule/directory/Directory.tsx
+++ b/src/pages/timecapsule/directory/Directory.tsx
@@ -1,80 +1,28 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import MainLayout from '../../../layout/MainLayout';
-import Menu from '../../../components/common/Menu';
-import * as S from '../../../styles/timecapsule/directory/Directory.style';
 import CapsuleContainer from '../../../components/timecapsule/directory/Capsules';
-import { useUserStore } from '../../../store/userStore';
 import { fetchLetterData } from '../../../api/directoryLetter';
-import { handleButtonClick } from './directoryButtonUtil';
+import Header from '../../../components/common/Header';
 
 interface IDirectory {
   pageType: string;
 }
 
 const Directory = ({ pageType }: IDirectory) => {
-  const navigate = useNavigate();
-  const nickname = useUserStore((state) => state.nickname);
-
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [letterData, setLetterData] = useState([]);
-  const [directoryState, setDirectoryState] = useState({
-    pageType,
-    buttonLabel:
-      pageType === '일일회고' ? '타임캡슐 보러가기' : '일일회고 보러가기',
-  });
-
-  const toggleMenu = () => {
-    setIsMenuOpen((prev) => !prev);
-  };
-
-  const closeMenu = () => {
-    setIsMenuOpen(false);
-  };
 
   useEffect(() => {
     const loadData = async () => {
-      const data = await fetchLetterData(directoryState.pageType);
+      const data = await fetchLetterData(pageType);
       setLetterData(data);
     };
     loadData();
-  }, [directoryState.pageType]);
+  }, [pageType]);
 
   return (
     <MainLayout>
-      <S.Header>
-        <S.LeftBox>
-          <S.LogoText href="/main">Time Capsule</S.LogoText>
-          <S.TitleText>
-            {nickname} 님의 {directoryState.pageType} 보관함
-          </S.TitleText>
-          <S.ChangeButton
-            onClick={() =>
-              handleButtonClick(directoryState, setDirectoryState, navigate)
-            }
-          >
-            {directoryState.buttonLabel}
-          </S.ChangeButton>
-        </S.LeftBox>
-        <S.RightBox>
-          <S.MenuImg
-            src="/header/menu.svg"
-            width={35}
-            height={35}
-            onClick={toggleMenu}
-          />
-          {isMenuOpen && (
-            <>
-              <S.Overlay onClick={closeMenu} />
-              <Menu type="directory" />
-            </>
-          )}
-        </S.RightBox>
-      </S.Header>
-      <CapsuleContainer
-        letterData={letterData}
-        pageType={directoryState.pageType}
-      />
+      <Header pageType={pageType} />
+      <CapsuleContainer letterData={letterData} pageType={pageType} />
     </MainLayout>
   );
 };

--- a/src/styles/common/Header.style.ts
+++ b/src/styles/common/Header.style.ts
@@ -1,50 +1,73 @@
 import styled from 'styled-components';
 
 export const HeaderContainer = styled.div`
-	display: flex;
-	align-items: center;
-	width: 100%;
-	height: 100px;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  position: relative;
+  top: 1rem;
+
+  @media (max-width: 768px) {
+    width: calc(100vw - 40px);
+    flex-direction: column;
+  }
 `;
 
-export const LogoContainer = styled.div`
-	width: auto;
-	height: 25px;
-	margin-left: 25px;
-	font-size: 24px;
-	font-weight: bold;
-	color: ${(props) => (props.isTodo ? 'black' : 'beige')};
-	cursor: pointer;
+interface StyledProps {
+  isTodo?: boolean;
+}
+
+export const LogoContainer = styled.div<StyledProps>`
+  width: auto;
+  font-size: 1.5rem;
+  font-weight: bold;
+  cursor: pointer;
+  color: ${(props) => (props.isTodo ? 'beige' : 'black')};
 `;
 
-export const HeaderTitle = styled.div`
-	width: auto;
-	height: 25px;
-	margin-left: 25px;
-	font-size: 24px;
-	font-weight: 600;
-	color: ${(props) => (props.isTodo ? 'black' : 'white')};
+export const HeaderTitle = styled.div<StyledProps>`
+  width: auto;
+  margin-left: 25px;
+  font-size: 1.5rem;
+  color: ${(props) => (props.isTodo ? 'beige' : 'black')};
 `;
 
-export const MenuContainer = styled.div`
-	margin-left: auto;
-	position: absolute;
-	right: 50px;
-	cursor: pointer;
-	z-index: 100;
+export const MenuContainer = styled.div<StyledProps>`
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  cursor: pointer;
+  z-index: 100;
 
-	img {
-		filter: ${(props) =>
-			props.isTodo ? 'invert(1)' : 'invert(0)'};
-	}
+  img {
+    filter: ${(props) => (props.isTodo ? 'invert(0)' : 'invert(1)')};
+  }
 `;
 
 export const Overlay = styled.div`
-	position: fixed;
-	top: 0;
-	left: 0;
-	width: 100vw;
-	height: 100vh;
-	background-color: rgba(0, 0, 0, 0.5);
-	z-index: 99;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 99;
+`;
+
+export const ChangeButton = styled.button`
+  margin-left: 1rem;
+  padding: 0.37rem 1rem;
+  border: none;
+  border-radius: 0.825rem;
+
+  font-size: 1em;
+  font-weight: 600;
+  background-color: #dadada;
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: #cacaca;
+  }
 `;

--- a/src/styles/common/Loading.style.ts
+++ b/src/styles/common/Loading.style.ts
@@ -10,6 +10,7 @@ export const LoadingOverlay = styled.div`
   justify-content: center;
   align-items: center;
   z-index: 9999;
+  background-color: rgba(255, 255, 255, 0.8);
 `;
 
 export const LoadingImage = styled.img`

--- a/src/styles/common/Menu.style.ts
+++ b/src/styles/common/Menu.style.ts
@@ -1,19 +1,13 @@
 import styled from 'styled-components';
 
-interface MenuContainerProps {
-  type: 'directory' | 'default';
-}
 
-export const MenuContainer = styled.div<MenuContainerProps>`
+export const MenuContainer = styled.div`
   display: flex;
   flex-direction: column;
   position: absolute;
-  top: ${(props) => {
-    return props.type === 'directory' ? '120px' : '450px';
-  }};
-  right: ${(props) => {
-    return props.type === 'directory' ? '40px' : '0px';
-  }};
+  top: 100%;
+  margin-top: 2rem;
+  right: 0;
   gap: 30px;
   z-index: 100;
 `;

--- a/src/styles/layout/MainLayout.style.ts
+++ b/src/styles/layout/MainLayout.style.ts
@@ -1,16 +1,15 @@
 import styled from 'styled-components';
 
 export const MainLayoutContainer = styled.div`
-	display: flex;
-	flex-direction: column;
+  display: flex;
+  flex-direction: column;
 
-	max-width: 1200px;
-	min-width: 700px;
+  max-width: 1200px;
 
-	height: 100vh;
+  height: 100vh;
 
-	margin: 0 auto;
-	padding: 20px;
+  margin: 0 auto;
+  padding: 30px;
 
-	position: relative;
+  position: relative;
 `;

--- a/src/styles/timecapsule/MainPage.style.ts
+++ b/src/styles/timecapsule/MainPage.style.ts
@@ -3,14 +3,15 @@ import styled from 'styled-components';
 export const MainContainer = styled.div`
   width: 100vw;
   height: 100vh;
-
+  overflow: auto;
   background: url('/background.png') no-repeat;
   background-size: cover;
+  background-position: center;
 `;
 
 export const MainContent = styled.div`
   display: flex;
   justify-content: center;
-  align-items: end;
-  flex: 1;
+  align-items: center;
+  flex-grow: 1;
 `;

--- a/src/styles/timecapsule/directory/Directory.style.ts
+++ b/src/styles/timecapsule/directory/Directory.style.ts
@@ -1,68 +1,11 @@
-import { BottomSection } from './../main/CapsuleBox.style';
 import styled from 'styled-components';
-
-export const Header = styled.header`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  width: 100%;
-  padding: 35px 0;
-
-  background-color: #ffffff;
-`;
-
-export const LeftBox = styled.div`
-  display: flex;
-  align-items: center;
-  margin-left: 25px;
-  gap: 1rem;
-`;
-
-export const LogoText = styled.a`
-  font-size: 1.5em;
-  font-weight: bold;
-`;
-
-export const TitleText = styled.span`
-  font-size: 1.2em;
-  text-align: center;
-`;
-
-export const ChangeButton = styled.button`
-  padding: 0.5rem 1rem;
-
-  border: none;
-  border-radius: 0.825rem;
-
-  font-size: 1em;
-  font-weight: 600;
-  background-color: #dadada;
-
-  cursor: pointer;
-
-  &:hover {
-    background-color: #cacaca;
-  }
-`;
-
-export const RightBox = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
-export const MenuImg = styled.img`
-  margin-bottom: 15px;
-  margin-right: 30px;
-  cursor: pointer;
-`;
 
 export const CapsuleContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(6, 1fr);
 
   gap: 1.5rem;
-  padding-top: 4rem;
+  padding-top: 5rem;
 `;
 
 export const CapsuleBox = styled.div`
@@ -93,14 +36,4 @@ export const CapsuleImg = styled.img`
 
   border-radius: 50%;
   object-fit: cover;
-`;
-
-export const Overlay = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background-color: rgba(0, 0, 0, 0.5);
-  z-index: 99;
 `;

--- a/src/styles/timecapsule/main/CapsuleBox.style.ts
+++ b/src/styles/timecapsule/main/CapsuleBox.style.ts
@@ -1,47 +1,47 @@
 import styled from 'styled-components';
 
 export const CapsuleBoxContainer = styled.div`
-	display: flex;
-	flex-direction: column;
-	justify-content: end;
-	align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-top: 5rem;
 `;
 
 export const TitleContainer = styled.div`
-	display: flex;
-	flex-direction: column;
-	margin-bottom: 20px;
-	color: beige;
+  display: flex;
+  flex-direction: column;
+  color: beige;
 `;
 
 export const TopSection = styled.div`
-	display: flex;
-	justify-content: center;
-	font-size: 26px;
-	font-weight: bold;
+  display: flex;
+  justify-content: center;
+  font-size: 26px;
+  font-weight: bold;
 `;
 
 export const BottomSection = styled.div`
-	display: flex;
-	font-size: 26px;
-	justify-content: center;
-	align-items: center;
+  display: flex;
+  font-size: 26px;
+  justify-content: center;
+  align-items: center;
 
-	img {
-		margin-bottom: 6px;
-	}
+  img {
+    margin-bottom: 6px;
+  }
 
-	span {
-		font-size: 32px;
-		font-weight: bold;
-		margin-right: 5px;
-	}
+  span {
+    font-size: 32px;
+    font-weight: bold;
+    margin-right: 5px;
+  }
 `;
 
 export const BoxContainer = styled.div`
-	display: flex;
-	justify-content: center;
-	align-items: end;
-	width: 100%;
-	cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: end;
+  width: 100%;
+  cursor: pointer;
 `;

--- a/src/styles/todo/TodoMainPage.style.ts
+++ b/src/styles/todo/TodoMainPage.style.ts
@@ -1,13 +1,17 @@
 import styled from 'styled-components';
 
 export const Content = styled.div`
-	display: flex;
-	justify-content: center;
-	align-items: start;
-	gap: 70px;
-	flex-grow: 1;
-	max-width: 1200px;
-	width: 100%;
-	box-sizing: border-box;
-	margin-top: 60px;
+  display: flex;
+  justify-content: center;
+  align-items: start;
+  flex-grow: 1;
+  max-width: 1200px;
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 6rem;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 20px; 
+  }
 `;

--- a/src/styles/todo/TodoMainPage.style.ts
+++ b/src/styles/todo/TodoMainPage.style.ts
@@ -6,12 +6,11 @@ export const Content = styled.div`
   align-items: start;
   flex-grow: 1;
   max-width: 1200px;
-  width: 100%;
   box-sizing: border-box;
   margin-top: 6rem;
 
   @media (max-width: 768px) {
     flex-direction: column;
-    gap: 20px; 
+    gap: 20px;
   }
 `;

--- a/src/styles/todo/main/AddTodo.style.ts
+++ b/src/styles/todo/main/AddTodo.style.ts
@@ -19,7 +19,7 @@ export const CategoryItem = styled.button<{ textColor: string }>`
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem 1rem;
-  background-color:rgb(243,243,243);
+  background-color: rgb(243, 243, 243);
   border-radius: 5rem;
   width: fit-content;
   font-weight: 800;
@@ -107,6 +107,7 @@ export const DropdownMenu = styled.div`
 export const DropdownItem = styled.div`
   padding: 8px 12px;
   cursor: pointer;
+  user-select: none;
 
   &:hover {
     background-color: #f0f0f0;

--- a/src/styles/todo/main/AddTodo.style.ts
+++ b/src/styles/todo/main/AddTodo.style.ts
@@ -42,7 +42,6 @@ export const InputGroup = styled.div`
   margin-top: 1rem;
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
 `;
 
 export const CheckBox = styled.input<{ textColor: string }>`
@@ -51,6 +50,7 @@ export const CheckBox = styled.input<{ textColor: string }>`
   height: 1.2rem;
   border: 1.5px solid gainsboro;
   border-radius: 0.35rem;
+  flex-shrink: 0;
 
   &:checked {
     border-color: transparent;
@@ -75,6 +75,7 @@ export const AddButton = styled.button<{ textColor: string }>`
   color: black;
   border: none;
   border-radius: 5px;
+  flex-shrink: 0;
 `;
 
 export const TodoItem = styled.div`

--- a/src/styles/todo/main/AddTodo.style.ts
+++ b/src/styles/todo/main/AddTodo.style.ts
@@ -1,11 +1,26 @@
 import styled from 'styled-components';
 
 export const TodoContainer = styled.div`
-  flex: 1;
+  flex-shrink: 0;
+  flex-grow: 1;
   background-color: white;
   padding: 1rem;
-  border-radius: 10px;
-  margin: 1rem;
+  align-items: center;
+
+  @media (min-width: 768px) {
+    max-height: calc(100vh - 300px);
+    overflow-y: auto;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  @media (max-width: 768px) {
+    width: calc(100vw - 40px);
+  }
 `;
 
 export const CategoryListContainer = styled.div`

--- a/src/styles/todo/main/AddTodo.style.ts
+++ b/src/styles/todo/main/AddTodo.style.ts
@@ -1,14 +1,15 @@
 import styled from 'styled-components';
 
 export const TodoContainer = styled.div`
-  flex-shrink: 0;
+  flex-shrink: 1;
   flex-grow: 1;
   background-color: white;
   padding: 1rem;
   align-items: center;
+  width: 600px;
 
   @media (min-width: 768px) {
-    max-height: calc(100vh - 300px);
+    max-height: calc(100vh - 250px);
     overflow-y: auto;
     scrollbar-width: none;
     -ms-overflow-style: none;
@@ -98,6 +99,7 @@ export const TodoItem = styled.div`
   display: flex;
   align-items: center;
   margin-top: 0.5rem;
+  margin-right: 0.5rem;
 `;
 
 export const TodoText = styled.p`

--- a/src/styles/todo/main/Calendar.style.ts
+++ b/src/styles/todo/main/Calendar.style.ts
@@ -6,15 +6,18 @@ export const CalendarContainer = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+
+  @media (max-width: 768px) {
+    width: calc(100vw - 40px);
+  }
 `;
 
 export const ProfileHeader = styled.div`
   display: flex;
   justify-content: space-between;
   width: 100%;
-  max-width: 600px;
   margin-bottom: 40px;
-  padding-left: 20px;
+  padding-left: 1rem;
 
   .profile {
     display: flex;
@@ -39,11 +42,10 @@ export const StyledCalendar = styled(Calendar)`
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  width: 100%;
-  max-width: 660px;
   border: none;
   font-size: 15px;
   font-weight: bold;
+  max-width: 600px;
 
   .react-calendar__month-view__weekdays {
     display: grid;
@@ -70,8 +72,7 @@ export const StyledCalendar = styled(Calendar)`
     display: grid;
     grid-template-columns: repeat(7, 1fr);
     grid-template-rows: repeat(6, 1fr);
-    width: 600px;
-    height: 340px;
+    height: auto;
   }
 
   .react-calendar__month-view__days :disabled {
@@ -115,6 +116,11 @@ export const StyledCalendar = styled(Calendar)`
       height: 22px;
       background-color: #d3d8db;
       border-radius: 5px;
+    }
+
+    & abbr {
+      display: inline-block;
+      width: 22px;
     }
 
     &.react-calendar__tile--active abbr {
@@ -195,7 +201,6 @@ export const TodoStatusBar = styled.div`
   display: flex;
   justify-content: space-between;
   width: 100%;
-  max-width: 600px;
   color: black;
 
   span {


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 메인, 달력, Todo, header 레이아웃 및 스타일 수정 
- [x] 디렉토리 페이지에서 '나의 보관함' 메뉴 항목 보이는 문제 수정
- [x] 로딩 페이지 디자인 수정

## 📝 작업 상세 내용

### 메인, 달력, Todo, Header 레이아웃 및 스타일 수정
반응형을 위해 전반적으로 레이아웃을 다 수정했습니다.

**메인**
- 메인 페이지에서 박스의 위치가 너무 아래에 있고 화면이 줄어들었을 때 헤더와 겹쳐져서 정렬을 수정

**헤더**
- 헤더 및 햄버거 메뉴 레이아웃을 수정하여 모든 페이지에서 일관된 크기와 위치를 유지하도록 조정

**달력**
- 달력에서 다른 날짜로 이동 시 할 일 입력창 초기화
- 달력 컴포넌트에서 `width: 100%`를 과도하게 사용하여 크기가 예상보다 왜곡되는 문제를 해결
- `width: 100%`는 부모 크기를 무조건 따라가므로 되도록 사용을 지양하고 대신 `flex-grow`를 사용해 적절히 크기를 조정하도록 수정
- 달력의 날짜를 클릭했을 때 달력의 크기가 움직이는 이유도 날짜가 한 자리 수 일 때랑 두 자리 수 일 때의 영역 값이 계속 달라졌기 때문이고 아래 코드를 입력해서 날짜의 영역을 날짜 선택됐을 때의 크기와 동일하게 맞춰주어 해결함
```
& abbr {
      display: inline-block;
      width: 22px;
    }
```

**투두**
- 각 할 일들의 dropdown 메뉴에서 텍스트 드래그 방지
- 할 일이 많아졌을 때 내부 스크롤이 되도록 구현
- 투두 리스트 여백 조정

### 디렉토리 페이지에서 '나의 보관함' 메뉴 항목 보이는 문제 수정
- 보관함 페이지로 이동했을 때도 '나의 편지함' 메뉴 항목이 나와서 다시 메인으로 갈 수 있는 '나의 타임캡슐' 항목을 추가
```
const menuItems = (() => {
    if (location.pathname.startsWith('/todo')) {
      return [
        { path: `/main`, label: '나의 타임캡슐' },
        { path: '/todo/category/new', label: '카테고리 등록' },
        { path: '/todo/category', label: '카테고리 관리' },
      ];
    } else if (location.pathname.startsWith('/directory')) {
      return [
        { path: `/main`, label: '나의 타임캡슐' },
        { path: `/todo`, label: '나의 Todo' },
      ];
    } else {
      return [
        { path: `/todo`, label: '나의 Todo' },
        { path: `/directory/letter`, label: '나의 편지함' },
      ];
    }
  })();
```

### 로딩 페이지 디자인 수정
- 흰 색 배경에 투명도 조절

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reviewers, assignees, Lables 등록 확인하기

**이슈 번호**: #138 
