### PR TITLE
[BUG] fix: 할 일 다른 날짜 등록 시 정렬 오류

### DIFF
--- a/src/api/todo.ts
+++ b/src/api/todo.ts
@@ -5,6 +5,7 @@ interface ITodo {
   task: string;
   isCompleted: boolean;
   categoryId: string;
+  selectedDate: string;
   createdAt: { seconds: number; nanoseconds: number };
 }
 
@@ -48,6 +49,7 @@ export const fetchTodoData = async () => {
         task: item.task,
         isCompleted: item.isCompleted,
         categoryId: item.categoryId,
+        selectedDate: item.selectedDate,
         createdAt: timestamp,
       };
     });
@@ -58,8 +60,8 @@ export const fetchTodoData = async () => {
     );
     const currentMonth = new Date().getMonth();
     const completedCount = sortedTodos.filter(
-      (todo: { createdAt: number; isCompleted: boolean }) => {
-        const todoDate = new Date(todo.createdAt);
+      (todo: { selectedDate: string; isCompleted: boolean }) => {
+        const todoDate = new Date(todo.selectedDate);
         return todo.isCompleted && todoDate.getMonth() === currentMonth;
       },
     ).length;

--- a/src/components/todo/main/AddTodo.tsx
+++ b/src/components/todo/main/AddTodo.tsx
@@ -1,6 +1,5 @@
 import { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from 'react';
 import * as S from '../../../styles/todo/main/AddTodo.style';
-import dayjs from 'dayjs';
 import useTodo from '../../../hooks/useTodo';
 import useCategory from '../../../hooks/useCategory';
 
@@ -122,8 +121,7 @@ export default function AddTodo({ selectedDate }: AddTodoProps) {
                 {Array.isArray(todos) &&
                   todos.map((todo) => {
                     if (
-                      selectedDate ===
-                        dayjs(todo.createdAt).format('YYYY-MM-DD') &&
+                      selectedDate === todo.selectedDate &&
                       todo.categoryId === category.id
                     ) {
                       return (

--- a/src/components/todo/main/Calendar.jsx
+++ b/src/components/todo/main/Calendar.jsx
@@ -18,7 +18,7 @@ const CustomCalendar = ({ onDateChange }) => {
 
   const completedTodosForMonth = (month) => {
     return todos.filter((todo) => {
-      const todoDate = new Date(todo.createdAt);
+      const todoDate = new Date(todo.selectedDate);
       return todoDate.getMonth() === month && todo.isCompleted;
     }).length;
   };
@@ -26,7 +26,7 @@ const CustomCalendar = ({ onDateChange }) => {
   const todosCountForDate = (date) => {
     return todos.filter(
       (todo) =>
-        new Date(todo.createdAt).toDateString() ===
+        new Date(todo.selectedDate).toDateString() ===
         new Date(date).toDateString(),
     ).length;
   };
@@ -34,7 +34,7 @@ const CustomCalendar = ({ onDateChange }) => {
   const todosCompletedCountForDate = (date) => {
     return todos.filter(
       (todo) =>
-        new Date(todo.createdAt).toDateString() ===
+        new Date(todo.selectedDate).toDateString() ===
           new Date(date).toDateString() && todo.isCompleted,
     ).length;
   };


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 할 일 정렬 시 `createdAt` 기반으로 정확한 순서 보장

## 📝 작업 상세 내용
기존에는 다른 날짜에 할 일을 작성하면 할 일을 작성한 날짜에 시간은 현재 시간을 가져와서 수정하여 저장하였는데 오류가 발생하였습니다.
예를 들어 2월 16일 오후 1시에 할 일을 등록했는데 2월 17일 오전 1시에 16일에 대한 할 일을 작성하면 17일 오전 1시에 작성한 것이 16일 날 작성한 할 일 보다 먼저 정렬되는 오류였습니다.
 `selectedDate`와 `createdAt`을 각각 저장하여 해당 날짜에 맞게 달력에 나타내주고 정확한 순서를 보장하도록 수정하였습니다.

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #143 