### PR TITLE
[FEAT] feat: 편지, 회고 작성 페이지 뒤로가기 기능 구현 및 beforeunload 오류 수정

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -21,7 +21,7 @@ const Header = ({ pageType }: HeaderProps) => {
     if (location.pathname.startsWith('/todo'))
       return `${nickname}님의 할 일 목록`;
     if (location.pathname.startsWith('/directory'))
-      return `${nickname} 님의 ${pageType} 보관함`;
+      return `${nickname}님의 ${pageType} 보관함`;
   };
 
   const handleMainNav = () => {

--- a/src/components/timecapsule/write/WriteForm.tsx
+++ b/src/components/timecapsule/write/WriteForm.tsx
@@ -3,6 +3,7 @@ import * as S from '../../../styles/timecapsule/write/WriteForm.style';
 import WriteButton from './WriteButton';
 import { submitLetter } from '../../../api/letter';
 import { submitReflect } from '../../../api/reflect';
+import { useNavigate } from 'react-router-dom';
 
 interface WriteFormProps {
   placeholder: string;
@@ -16,6 +17,7 @@ export default function WriteForm({
   emoji,
 }: WriteFormProps) {
   const [content, setContent] = useState('');
+  const navigate = useNavigate();
 
   const handleContentChange = (
     event: React.ChangeEvent<HTMLTextAreaElement>,
@@ -41,13 +43,12 @@ export default function WriteForm({
     try {
       if (mode === 'letter') {
         await submitLetter(content);
-        alert('편지가 등록되었습니다.');
-        window.location.href = '/directory/letter';
       } else if (mode === 'reflect') {
         await submitReflect(content, emoji!);
-        alert('회고가 등록되었습니다.');
-        window.location.href = '/directory/reflect';
       }
+
+      alert(`${mode === 'letter' ? '편지' : '회고'}가 등록되었습니다.`);
+      navigate(`/directory/${mode}`);
     } catch {
       alert(
         `${mode === 'letter' ? '편지' : '회고'} 등록에 실패했습니다. 다시 시도해주세요.`,

--- a/src/components/todo/category/CategoryModal.tsx
+++ b/src/components/todo/category/CategoryModal.tsx
@@ -63,7 +63,7 @@ const CategoryModal: React.FC<CategoryModalProps> = ({
           <S.MainMessage>
             해당 카테고리를 삭제하시겠습니까?
             <br />
-            "포함되어 있던 할 일들은 모두 삭제됩니다."
+            포함되어 있던 할 일들은 모두 삭제됩니다.
           </S.MainMessage>
         )}
         <S.ButtonGroup>

--- a/src/pages/timecapsule/write/LetterWritePage.tsx
+++ b/src/pages/timecapsule/write/LetterWritePage.tsx
@@ -2,6 +2,7 @@ import * as S from '../../../styles/timecapsule/write/WritePage.style';
 import WriteForm from '../../../components/timecapsule/write/WriteForm';
 import { StarsBackground } from '../../../components/timecapsule/write/StarsBackground';
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default function LetterWritePage() {
   useEffect(() => {
@@ -17,9 +18,16 @@ export default function LetterWritePage() {
     };
   }, []);
 
+  const nav = useNavigate();
+
+  const handleBackNav = () => {
+    nav(-1);
+  };
+
   return (
     <S.WriteContainer>
       <StarsBackground />
+      <S.BackButton onClick={handleBackNav}>{'<'}</S.BackButton>
       <S.TitleContainer>
         <S.Title>Time Capsule</S.Title>
         <S.SubTitle>미래의 나에게 편지를 보내자!</S.SubTitle>

--- a/src/pages/timecapsule/write/ReflectWritePage.tsx
+++ b/src/pages/timecapsule/write/ReflectWritePage.tsx
@@ -2,6 +2,7 @@ import * as S from '../../../styles/timecapsule/write/WritePage.style';
 import WriteForm from '../../../components/timecapsule/write/WriteForm';
 import { StarsBackground } from '../../../components/timecapsule/write/StarsBackground';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default function ReflectWritePage() {
   const emotions = [
@@ -33,9 +34,16 @@ export default function ReflectWritePage() {
     };
   }, []);
 
+  const nav = useNavigate();
+
+  const handleBackNav = () => {
+    nav(-1);
+  };
+
   return (
     <S.WriteContainer>
       <StarsBackground />
+      <S.BackButton onClick={handleBackNav}>{'<'}</S.BackButton>
       <S.TitleContainer>
         <S.Title>오늘의 일기</S.Title>
         <S.SubTitle>오늘은 어떤 하루였나요?</S.SubTitle>

--- a/src/styles/timecapsule/write/CustomButton.style.ts
+++ b/src/styles/timecapsule/write/CustomButton.style.ts
@@ -5,7 +5,5 @@ export const Button = styled.button`
   padding: 10px;
   border-radius: 10px;
   font-size: 16px;
-  margin-bottom: 2rem;
   background-color: ${({ color }) => color || '#222222'};
-  box-shadow: rgba(0, 0, 0, 0.2) 0px 60px 40px -7px;
 `;

--- a/src/styles/timecapsule/write/WritePage.style.ts
+++ b/src/styles/timecapsule/write/WritePage.style.ts
@@ -12,8 +12,15 @@ export const TitleContainer = styled.div`
   justify-content: center;
   align-items: center;
   text-align: center;
-  padding: 1rem;
-  margin-top: 2rem;
+`;
+
+export const BackButton = styled.div`
+  font-size: 2.5rem;
+  color: rgb(252, 229, 194);
+  cursor: pointer;
+  margin-top: 0.2rem;
+  margin-left: 2rem;
+  text-shadow: 3px 3px 5px rgba(0, 0, 0, 0.6);
 `;
 
 export const Title = styled.div`
@@ -35,7 +42,7 @@ export const Title = styled.div`
 export const SubTitle = styled.div`
   font-weight: bold;
   font-size: 1.5rem;
-  margin: 1rem;
+  margin-bottom: 1rem;
   color: rgb(251, 233, 206);
   text-shadow: 3px 3px 5px rgba(0, 0, 0, 0.6);
 


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 편지, 회고 작성 페이지 뒤로가기 기능 구현
- [x] 편지, 회고 작성 완료 후 보관함으로 페이지 이동 시 beforeunload가 계속 뜨는 오류 수정
- [x] 보관함 헤더, Todo 카테고리 관리 알림창 오타 및 불필요한 문자 삭제

## 📝 작업 상세 내용

편지, 회고 페이지에서 글 작성 후 등록했을 때 보관함으로 이동할 때에는 beforeunload가 발생하면 안 되는데 발생되는 오류가 있었습니다. 발생한 이유는 페이지 이동할  때 `window.location.href`를 사용했기 때문이었습니다. `useNavigate`를 사용하여 오류를 해결하였습니다.

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #152 
